### PR TITLE
add CI job to enforce CHANGELOG.md updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,18 @@ name: Go
 on:
   push:
     branches: main
-  pull_request: # don't include branches so that all PRs run.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "skip-changelog,ignore-release"
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use the dangoslen/changelog-enforcer marketplace action to ensure that the CHANGELOG.md
is being updated with each PR merged into the repo. This can be bypassed for
changes that are not customer impacting by applying the `skip-changelog` or
`ignore-release` labels to the PR.
