### PR TITLE
Add support for `drop_nan_value` in Drop Rule resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+- Add support for `drop_nan_value` in `chronosphere_drop_rule` resource
+
 Deprecated:
 - Remove unsupported `bucket_id` in `chronosphere_notification_policy`

--- a/chronosphere/intschema/drop_rule.go
+++ b/chronosphere/intschema/drop_rule.go
@@ -20,6 +20,7 @@ type DropRule struct {
 	ActivatedDropDuration string                  `intschema:"activated_drop_duration,optional"`
 	Active                bool                    `intschema:"active,optional,default:false"`
 	ConditionalDrop       bool                    `intschema:"conditional_drop,optional"`
+	DropNanValue          bool                    `intschema:"drop_nan_value,optional"`
 	RateLimitThreshold    float64                 `intschema:"rate_limit_threshold,optional"`
 	ValueBasedDrop        *DropRuleValueBasedDrop `intschema:"value_based_drop,optional,list_encoded_object"`
 

--- a/chronosphere/resource_drop_rule.go
+++ b/chronosphere/resource_drop_rule.go
@@ -75,6 +75,7 @@ func (dropRuleConverter) toModel(
 		Mode:                     dropRuleModeToModel(r.Active),
 		Filters:                  filter,
 		ConditionalRateBasedDrop: conditionalRateBasedDrop,
+		DropNanValue:             r.DropNanValue,
 		ValueBasedDrop:           valueBaseDropToModel(r.ValueBasedDrop),
 	}, nil
 }
@@ -87,6 +88,7 @@ func (dropRuleConverter) fromModel(
 		Slug:           m.Slug,
 		Active:         m.Mode == models.Configv1DropRuleModeENABLED,
 		Query:          aggregationfilter.ListFromModel(m.Filters, aggregationfilter.DropRuleDelimiter),
+		DropNanValue:   m.DropNanValue,
 		ValueBasedDrop: valueBasedDropFromModel(m.ValueBasedDrop),
 	}
 	if m.ConditionalRateBasedDrop != nil {

--- a/chronosphere/tfschema/drop_rule.go
+++ b/chronosphere/tfschema/drop_rule.go
@@ -46,6 +46,10 @@ var DropRule = map[string]*schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 	},
+	"drop_nan_value": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
 	"activated_drop_duration": Duration{
 		Optional: true,
 	}.Schema(),


### PR DESCRIPTION
drop_nan_value allows you to drops datapoints if the datapoint
values are NaN. This change adds support for that field.
