### PR TITLE
Remove local rollup rule validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 Deprecated:
 - Remove unsupported `bucket_id` in `chronosphere_notification_policy`
+- Remove in-provider validation of rollup rules in favor of server-side dry run validation

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -39,8 +39,7 @@ var RollupRule = map[string]*schema.Schema{
 		KVDelimiter: aggregationfilter.RollupRuleDelimiter,
 	}.Schema(),
 	"new_metric": {
-		Type: schema.TypeString,
-		// Required unless metric_type == DELTA, validated in chronosphere.validateRollupRule().
+		Type:     schema.TypeString,
 		Optional: true,
 	},
 	"metric_type": Enum{


### PR DESCRIPTION
Remove local rollup rule validation

Instead of doing validation locally we will start to fully rely on
dry run validation that we do for all resources that support it.

The rationale behind this is that changes/additions to the APIs
may render a local check obsolete and require a new version of
the Terraform provider when it is not necessary. This has been
seen recently as the result of additionally functionality added
to rollup rules

update CHANGELOG
