### PR TITLE
Adds name field to chronosphere_dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Added:
 - Add `gcp_metrics_integration` resource
 - Add new resource type, `dataset`, with the first telemetry type supported being tracing.
 - Add new `IN` and `NOT_IN` variations to tracing's `StringFilterMatchType` enum.
+- Add `name` field to `dashboard` resource.
 
 Deprecated:
 - Block unsupported use of duplicate routes with the same severity in `chronosphere_notification_policy`

--- a/chronosphere/intschema/dashboard.go
+++ b/chronosphere/intschema/dashboard.go
@@ -14,6 +14,7 @@ import (
 var _ tfid.ID // Always use tfid for simplified import generation.
 
 type Dashboard struct {
+	Name                 string  `intschema:"name,optional"`
 	Slug                 string  `intschema:"slug,optional,computed"`
 	CollectionId         tfid.ID `intschema:"collection_id,optional"`
 	DashboardJson        string  `intschema:"dashboard_json"`

--- a/chronosphere/tfschema/dashboard.go
+++ b/chronosphere/tfschema/dashboard.go
@@ -20,6 +20,10 @@ import (
 )
 
 var Dashboard = map[string]*schema.Schema{
+	"name": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 	"slug": {
 		Type:     schema.TypeString,
 		Optional: true,


### PR DESCRIPTION
Originally the name was extracted from the dashboard_json metadata. This is confusing/inconsistent with how we treat other resources. The public API also supports a top level name field. We have deprecated the metadata field as well.

This PR adds the name field to our dashboard resource, implementing a one_of between name and json.metadata.name.

The lack of either name fields being set results in a validation error from the API.