### PR TITLE
Support migration from storage_policies to interval [sc-81013]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Updated:
 - Renamed `chronosphere_grafana_dashboard` to `chronosphere_classic_dashboard`
 - Add new `IN` and `NOT_IN` variations to tracing's `StringFilterMatchType` enum.
 
+Fixed:
+- Fix `chronosphere_rollup_rule` migration from `storage_policies` to `interval`.
+
 Deprecated:
 - Block unsupported use of duplicate routes with the same severity in `chronosphere_notification_policy`
 - Remove unsupported `bucket_id` in `chronosphere_notification_policy`

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -69,8 +69,9 @@ var RollupRule = map[string]*schema.Schema{
 		Computed: true,
 	},
 	"interval": {
-		Type:     schema.TypeString,
-		Optional: true,
+		Type:          schema.TypeString,
+		Optional:      true,
+		ConflictsWith: []string{"storage_policies"},
 	},
 	"group_by": {
 		Type:     schema.TypeList,


### PR DESCRIPTION
[sc-81013]

Currently, migrating from storage_policies to interval is not possible as the provider receives both fields set, even if storage_policies is no longer set. This seems like an issue with the plugin sdk, as it's passing the last returned server value, even if the user deletes the config.

However, we can workaround this by:
 * Ensuring the config doesn't allow both to be set by using `ConflictsWith`, which only triggers if the config has both set.
 * Clearing storage_policies if it's set alongside interval, since we know that both cannot be set due to the above validation.