### PR TITLE
Deprecate storage policies in mapping and rollup rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Deprecated:
 - Remove deprecated `rules` field from `chronosphere_notification_policy`
 - Remove in-provider validation of rollup rules in favor of server-side dry run validation
 - Consolidating tracing schemas: replace usage of `tags` with `tag`, `min_seconds` with `min_secs`, and `max_seconds` with `max_secs`.
+- Deprecate `chronosphere_rollup_rule.storage_policies` and `chronsphere_mapping_rule.storage_policy` and recomment `interval`
 
 Internal:
 - Validate code generation in pull request CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Deprecated:
 - Remove deprecated `rules` field from `chronosphere_notification_policy`
 - Remove in-provider validation of rollup rules in favor of server-side dry run validation
 - Consolidating tracing schemas: replace usage of `tags` with `tag`, `min_seconds` with `min_secs`, and `max_seconds` with `max_secs`.
-- Deprecate `chronosphere_rollup_rule.storage_policies` and `chronsphere_mapping_rule.storage_policy` and recomment `interval`
+- Deprecate `chronosphere_rollup_rule.storage_policies` and `chronsphere_mapping_rule.storage_policy` and recommend `interval`
 
 Internal:
 - Validate code generation in pull request CI

--- a/chronosphere/tfschema/mapping_rule.go
+++ b/chronosphere/tfschema/mapping_rule.go
@@ -61,6 +61,7 @@ var MappingRule = map[string]*schema.Schema{
 				}.Schema(),
 			},
 		},
+		Deprecated: "use `interval` instead",
 	},
 	"drop": {
 		Type:     schema.TypeBool,

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -66,7 +66,8 @@ var RollupRule = map[string]*schema.Schema{
 			},
 		},
 		// When no policies are specified, the server-side will set the defaults.
-		Computed: true,
+		Computed:   true,
+		Deprecated: "use `interval` instead",
 	},
 	"interval": {
 		Type:          schema.TypeString,


### PR DESCRIPTION
interval replaces storage_policies, is simpler for users, and avoids users needing to figure out the correct retention value.