### PR TITLE
Deprecate mapping_rule.drop_timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Deprecated:
  * `proxy_url` is deprecated in alert receivers. 
+ * `chronosphere_mapping_rule.drop_timestamp` is deprecated.
 
 ## v1.0.0
 

--- a/chronosphere/tfschema/mapping_rule.go
+++ b/chronosphere/tfschema/mapping_rule.go
@@ -70,9 +70,10 @@ var MappingRule = map[string]*schema.Schema{
 	},
 	// Whether or not to drop the timestamp.
 	"drop_timestamp": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
+		Type:       schema.TypeBool,
+		Optional:   true,
+		Default:    false,
+		Deprecated: "drop timestamp is no longer supported",
 	},
 	"interval": {
 		Type:     schema.TypeString,


### PR DESCRIPTION
See sc-73701 for details.