### PR TITLE
intschema: Use tfid for bucket.notification_policy_data

### DIFF
--- a/chronosphere/intschema/bucket.go
+++ b/chronosphere/intschema/bucket.go
@@ -16,12 +16,12 @@ var _ tfid.ID // Always use tfid for simplified import generation.
 type Bucket struct {
 	Name                   string            `intschema:"name"`
 	Slug                   string            `intschema:"slug,optional,computed"`
+	NotificationPolicyData tfid.ID           `intschema:"notification_policy_data,optional"`
 	NotificationPolicyId   tfid.ID           `intschema:"notification_policy_id,optional"`
 	TeamId                 tfid.ID           `intschema:"team_id,optional"`
 	NotificationPolicySlug string            `intschema:"notification_policy_slug,computed"`
 	Description            string            `intschema:"description,optional"`
 	Labels                 map[string]string `intschema:"labels,optional"`
-	NotificationPolicyData string            `intschema:"notification_policy_data,optional"`
 
 	// Internal identifier used in the .state file, i.e. ResourceData.Id().
 	// Cannot be set, else ToResourceData will panic.

--- a/chronosphere/intschema/generateintschema/main.go
+++ b/chronosphere/intschema/generateintschema/main.go
@@ -72,12 +72,13 @@ var sharedElemTypeNames = map[*schema.Resource]string{
 // should be generated as a tfid.ID or not (i.e. does the field refer to a
 // registered Terraform resource or not).
 var fieldIsTFID = map[string]bool{
-	"bucket_id":              true,
-	"collection_id":          true,
-	"dashboard_id":           true,
-	"notification_policy_id": true,
-	"team_id":                true,
-	"execution_group":        true,
+	"bucket_id":                true,
+	"collection_id":            true,
+	"dashboard_id":             true,
+	"notification_policy_id":   true,
+	"team_id":                  true,
+	"execution_group":          true,
+	"notification_policy_data": true,
 
 	"callback_id": false,
 	"external_id": false,

--- a/chronosphere/intschema/notification_policy.go
+++ b/chronosphere/intschema/notification_policy.go
@@ -16,9 +16,9 @@ var _ tfid.ID // Always use tfid for simplified import generation.
 type NotificationPolicy struct {
 	Name                   string                       `intschema:"name,optional"`
 	Slug                   string                       `intschema:"slug,optional,computed"`
+	NotificationPolicyData tfid.ID                      `intschema:"notification_policy_data,optional,computed"`
 	TeamId                 tfid.ID                      `intschema:"team_id,optional"`
 	IsIndependent          bool                         `intschema:"is_independent,computed"`
-	NotificationPolicyData string                       `intschema:"notification_policy_data,optional,computed"`
 	Route                  []NotificationRoute          `intschema:"route,optional"`
 	Override               []NotificationPolicyOverride `intschema:"override,optional"`
 

--- a/chronosphere/resource_bucket.go
+++ b/chronosphere/resource_bucket.go
@@ -167,7 +167,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any) d
 			if err != nil {
 				return diag.Errorf("unable to convert notification policy: %v", err)
 			}
-			b.NotificationPolicyData = notificationPolicyData
+			b.NotificationPolicyData = tfid.Slug(notificationPolicyData)
 		}
 	}
 	return b.ToResourceData(d)

--- a/chronosphere/resource_notification_policy_independent.go
+++ b/chronosphere/resource_notification_policy_independent.go
@@ -90,7 +90,7 @@ func (independentNotificationPolicyConverter) fromModel(
 		TeamId:                 tfid.Slug(m.TeamSlug),
 		Override:               overrides,
 		Route:                  routes,
-		NotificationPolicyData: tfschema.IndependentNotificationPolicyData,
+		NotificationPolicyData: tfid.Slug(tfschema.IndependentNotificationPolicyData),
 		IsIndependent:          true,
 	}, nil
 }


### PR DESCRIPTION
This doesn't impact the provider logic, this makes it easier for tests to generate tf schemas where the notification_policy_data is a reference.