### PR TITLE
[resource-pools] align allocation sum validation w/ server validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Bug fixes:
+ * Fixed bug where `chronosphere_resource_pools_config` would not allow certain combinations
+   of allocation percents due to float arithmetic not adding to exactly 100%.
+
 Added:
  * Add unstable `otel_metrics_ingestion` resource.
 

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -246,7 +246,9 @@ func validateResourcePoolsConfig(cfg *apimodels.Configv1ResourcePools) error {
 			return err
 		}
 	}
-	if sum != 100 {
+	// We support allocations up to three decimal places.
+	// TODO(codyg): dry run validation to avoid duplicating this logic.
+	if sum < 99.999 || sum > 100.001 {
 		return stderrors.New("total allocation must sum to 100%")
 	}
 


### PR DESCRIPTION
I'm not sure why we didn't implement dry run validation for resource
pools, but it means that validation is divergent between terraform
and the API. In particular, the API allows resource pools allocation sums
to be within 3 decimal places of 100%, which avoids float arithmetic errors,
which can happen when adding certain floats (e.g. certain values like 0.666).
This PR updates the terraform validation to match the API validation.

Tested locally w/ dev examples.
