### PR TITLE
resource_pools: Use genericResource, and use server dry-run to replace validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Deprecated:
  * `proxy_url` is deprecated in alert receivers.
  * `chronosphere_mapping_rule.drop_timestamp` is deprecated.
 
+Bug fixes:
+* Fixed bug where `chronosphere_resource_pools_config` would not allow certain combinations
+  of allocation percents due to float arithmetic not adding to exactly 100%. TF now relies
+  on server-side validation of pools.
+
 ## v1.0.0
 
 Initial public release for terraform-provider-chronosphere.

--- a/chronosphere/generated_resources.gen.go
+++ b/chronosphere/generated_resources.gen.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/apiclients"
+	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configunstable/client/otel_metrics_ingestion"
+	configunstablemodels "github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configunstable/models"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/bucket"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/collection"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/dashboard"
@@ -21,11 +23,13 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/notification_policy"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/notifier"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/recording_rule"
+	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/resource_pools"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/rollup_rule"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/service_account"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/team"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/trace_jaeger_remote_sampling_strategy"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/trace_metrics_rule"
+	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/trace_tail_sampling_rules"
 	configv1models "github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
 )
 
@@ -56,7 +60,7 @@ func (generatedBucket) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedBucket{}).slugOf(e), nil
 }
 
 func (generatedBucket) read(
@@ -84,7 +88,9 @@ func (generatedBucket) update(
 	req := &bucket.UpdateBucketParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateBucketBody{
+
 			Bucket:          m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -133,7 +139,7 @@ func (generatedCollection) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedCollection{}).slugOf(e), nil
 }
 
 func (generatedCollection) read(
@@ -161,7 +167,9 @@ func (generatedCollection) update(
 	req := &collection.UpdateCollectionParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateCollectionBody{
+
 			Collection:      m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -210,7 +218,7 @@ func (generatedDashboard) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedDashboard{}).slugOf(e), nil
 }
 
 func (generatedDashboard) read(
@@ -238,7 +246,9 @@ func (generatedDashboard) update(
 	req := &dashboard.UpdateDashboardParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateDashboardBody{
+
 			Dashboard:       m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -287,7 +297,7 @@ func (generatedDataset) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedDataset{}).slugOf(e), nil
 }
 
 func (generatedDataset) read(
@@ -315,7 +325,9 @@ func (generatedDataset) update(
 	req := &dataset.UpdateDatasetParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateDatasetBody{
+
 			Dataset:         m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -364,7 +376,7 @@ func (generatedDerivedLabel) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedDerivedLabel{}).slugOf(e), nil
 }
 
 func (generatedDerivedLabel) read(
@@ -392,7 +404,9 @@ func (generatedDerivedLabel) update(
 	req := &derived_label.UpdateDerivedLabelParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateDerivedLabelBody{
+
 			DerivedLabel:    m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -441,7 +455,7 @@ func (generatedDerivedMetric) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedDerivedMetric{}).slugOf(e), nil
 }
 
 func (generatedDerivedMetric) read(
@@ -469,7 +483,9 @@ func (generatedDerivedMetric) update(
 	req := &derived_metric.UpdateDerivedMetricParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateDerivedMetricBody{
+
 			DerivedMetric:   m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -518,7 +534,7 @@ func (generatedDropRule) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedDropRule{}).slugOf(e), nil
 }
 
 func (generatedDropRule) read(
@@ -546,7 +562,9 @@ func (generatedDropRule) update(
 	req := &drop_rule.UpdateDropRuleParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateDropRuleBody{
+
 			DropRule:        m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -595,7 +613,7 @@ func (generatedGcpMetricsIntegration) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedGcpMetricsIntegration{}).slugOf(e), nil
 }
 
 func (generatedGcpMetricsIntegration) read(
@@ -623,7 +641,9 @@ func (generatedGcpMetricsIntegration) update(
 	req := &gcp_metrics_integration.UpdateGcpMetricsIntegrationParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateGcpMetricsIntegrationBody{
+
 			GcpMetricsIntegration: m,
 			CreateIfMissing:       params.createIfMissing,
 			DryRun:                params.dryRun,
@@ -672,7 +692,7 @@ func (generatedClassicDashboard) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedClassicDashboard{}).slugOf(e), nil
 }
 
 func (generatedClassicDashboard) read(
@@ -700,7 +720,9 @@ func (generatedClassicDashboard) update(
 	req := &grafana_dashboard.UpdateGrafanaDashboardParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateGrafanaDashboardBody{
+
 			GrafanaDashboard: m,
 			CreateIfMissing:  params.createIfMissing,
 			DryRun:           params.dryRun,
@@ -749,7 +771,7 @@ func (generatedMappingRule) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedMappingRule{}).slugOf(e), nil
 }
 
 func (generatedMappingRule) read(
@@ -777,7 +799,9 @@ func (generatedMappingRule) update(
 	req := &mapping_rule.UpdateMappingRuleParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateMappingRuleBody{
+
 			MappingRule:     m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -826,7 +850,7 @@ func (generatedMonitor) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedMonitor{}).slugOf(e), nil
 }
 
 func (generatedMonitor) read(
@@ -854,7 +878,9 @@ func (generatedMonitor) update(
 	req := &monitor.UpdateMonitorParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateMonitorBody{
+
 			Monitor:         m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -903,7 +929,7 @@ func (generatedNotificationPolicy) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedNotificationPolicy{}).slugOf(e), nil
 }
 
 func (generatedNotificationPolicy) read(
@@ -931,7 +957,9 @@ func (generatedNotificationPolicy) update(
 	req := &notification_policy.UpdateNotificationPolicyParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateNotificationPolicyBody{
+
 			NotificationPolicy: m,
 			CreateIfMissing:    params.createIfMissing,
 			DryRun:             params.dryRun,
@@ -980,7 +1008,7 @@ func (generatedNotifier) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedNotifier{}).slugOf(e), nil
 }
 
 func (generatedNotifier) read(
@@ -1008,7 +1036,9 @@ func (generatedNotifier) update(
 	req := &notifier.UpdateNotifierParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateNotifierBody{
+
 			Notifier:        m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -1057,7 +1087,7 @@ func (generatedRecordingRule) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedRecordingRule{}).slugOf(e), nil
 }
 
 func (generatedRecordingRule) read(
@@ -1085,7 +1115,9 @@ func (generatedRecordingRule) update(
 	req := &recording_rule.UpdateRecordingRuleParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateRecordingRuleBody{
+
 			RecordingRule:   m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -1104,6 +1136,86 @@ func (generatedRecordingRule) delete(
 		Slug:    slug,
 	}
 	_, err := clients.ConfigV1.RecordingRule.DeleteRecordingRule(req)
+	return err
+}
+
+type generatedResourcePools struct{}
+
+func (generatedResourcePools) slugOf(m *configv1models.Configv1ResourcePools) string {
+	return ResourcePoolsConfigID
+}
+
+func (generatedResourcePools) create(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configv1models.Configv1ResourcePools,
+	dryRun bool,
+) (string, error) {
+	if dryRun {
+		return "", fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &resource_pools.CreateResourcePoolsParams{
+		Context: ctx,
+		Body: &configv1models.Configv1CreateResourcePoolsRequest{
+			ResourcePools: m,
+		},
+	}
+	resp, err := clients.ConfigV1.ResourcePools.CreateResourcePools(req)
+	if err != nil {
+		return "", err
+	}
+	e := resp.Payload.ResourcePools
+	if e == nil {
+		return "", nil
+	}
+	return (generatedResourcePools{}).slugOf(e), nil
+}
+
+func (generatedResourcePools) read(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) (*configv1models.Configv1ResourcePools, error) {
+	req := &resource_pools.ReadResourcePoolsParams{
+		Context: ctx,
+	}
+	resp, err := clients.ConfigV1.ResourcePools.ReadResourcePools(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload.ResourcePools, nil
+}
+
+func (generatedResourcePools) update(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configv1models.Configv1ResourcePools,
+	params updateParams,
+) error {
+	if params.dryRun {
+		return fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &resource_pools.UpdateResourcePoolsParams{
+		Context: ctx,
+
+		Body: &configv1models.Configv1UpdateResourcePoolsRequest{
+
+			ResourcePools:   m,
+			CreateIfMissing: params.createIfMissing,
+		},
+	}
+	_, err := clients.ConfigV1.ResourcePools.UpdateResourcePools(req)
+	return err
+}
+func (generatedResourcePools) delete(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) error {
+	req := &resource_pools.DeleteResourcePoolsParams{
+		Context: ctx,
+	}
+	_, err := clients.ConfigV1.ResourcePools.DeleteResourcePools(req)
 	return err
 }
 
@@ -1134,7 +1246,7 @@ func (generatedRollupRule) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedRollupRule{}).slugOf(e), nil
 }
 
 func (generatedRollupRule) read(
@@ -1162,7 +1274,9 @@ func (generatedRollupRule) update(
 	req := &rollup_rule.UpdateRollupRuleParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateRollupRuleBody{
+
 			RollupRule:      m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -1211,7 +1325,7 @@ func (generatedServiceAccount) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedServiceAccount{}).slugOf(e), nil
 }
 
 func (generatedServiceAccount) read(
@@ -1270,7 +1384,7 @@ func (generatedTeam) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedTeam{}).slugOf(e), nil
 }
 
 func (generatedTeam) read(
@@ -1298,7 +1412,9 @@ func (generatedTeam) update(
 	req := &team.UpdateTeamParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateTeamBody{
+
 			Team:            m,
 			CreateIfMissing: params.createIfMissing,
 			DryRun:          params.dryRun,
@@ -1347,7 +1463,7 @@ func (generatedTraceJaegerRemoteSamplingStrategy) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedTraceJaegerRemoteSamplingStrategy{}).slugOf(e), nil
 }
 
 func (generatedTraceJaegerRemoteSamplingStrategy) read(
@@ -1375,7 +1491,9 @@ func (generatedTraceJaegerRemoteSamplingStrategy) update(
 	req := &trace_jaeger_remote_sampling_strategy.UpdateTraceJaegerRemoteSamplingStrategyParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateTraceJaegerRemoteSamplingStrategyBody{
+
 			TraceJaegerRemoteSamplingStrategy: m,
 			CreateIfMissing:                   params.createIfMissing,
 			DryRun:                            params.dryRun,
@@ -1426,7 +1544,7 @@ func (generatedTraceMetricsRule) create(
 	if e == nil {
 		return "", nil
 	}
-	return e.Slug, nil
+	return (generatedTraceMetricsRule{}).slugOf(e), nil
 }
 
 func (generatedTraceMetricsRule) read(
@@ -1457,7 +1575,9 @@ func (generatedTraceMetricsRule) update(
 	req := &trace_metrics_rule.UpdateTraceMetricsRuleParams{
 		Context: ctx,
 		Slug:    m.Slug,
+
 		Body: &configv1models.ConfigV1UpdateTraceMetricsRuleBody{
+
 			TraceMetricsRule: m,
 			CreateIfMissing:  params.createIfMissing,
 		},
@@ -1475,5 +1595,165 @@ func (generatedTraceMetricsRule) delete(
 		Slug:    slug,
 	}
 	_, err := clients.ConfigV1.TraceMetricsRule.DeleteTraceMetricsRule(req)
+	return err
+}
+
+type generatedTraceTailSamplingRules struct{}
+
+func (generatedTraceTailSamplingRules) slugOf(m *configv1models.Configv1TraceTailSamplingRules) string {
+	return TraceTailSamplingRulesID
+}
+
+func (generatedTraceTailSamplingRules) create(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configv1models.Configv1TraceTailSamplingRules,
+	dryRun bool,
+) (string, error) {
+	if dryRun {
+		return "", fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &trace_tail_sampling_rules.CreateTraceTailSamplingRulesParams{
+		Context: ctx,
+		Body: &configv1models.Configv1CreateTraceTailSamplingRulesRequest{
+			TraceTailSamplingRules: m,
+		},
+	}
+	resp, err := clients.ConfigV1.TraceTailSamplingRules.CreateTraceTailSamplingRules(req)
+	if err != nil {
+		return "", err
+	}
+	e := resp.Payload.TraceTailSamplingRules
+	if e == nil {
+		return "", nil
+	}
+	return (generatedTraceTailSamplingRules{}).slugOf(e), nil
+}
+
+func (generatedTraceTailSamplingRules) read(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) (*configv1models.Configv1TraceTailSamplingRules, error) {
+	req := &trace_tail_sampling_rules.ReadTraceTailSamplingRulesParams{
+		Context: ctx,
+	}
+	resp, err := clients.ConfigV1.TraceTailSamplingRules.ReadTraceTailSamplingRules(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload.TraceTailSamplingRules, nil
+}
+
+func (generatedTraceTailSamplingRules) update(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configv1models.Configv1TraceTailSamplingRules,
+	params updateParams,
+) error {
+	if params.dryRun {
+		return fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &trace_tail_sampling_rules.UpdateTraceTailSamplingRulesParams{
+		Context: ctx,
+
+		Body: &configv1models.Configv1UpdateTraceTailSamplingRulesRequest{
+
+			TraceTailSamplingRules: m,
+			CreateIfMissing:        params.createIfMissing,
+		},
+	}
+	_, err := clients.ConfigV1.TraceTailSamplingRules.UpdateTraceTailSamplingRules(req)
+	return err
+}
+func (generatedTraceTailSamplingRules) delete(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) error {
+	req := &trace_tail_sampling_rules.DeleteTraceTailSamplingRulesParams{
+		Context: ctx,
+	}
+	_, err := clients.ConfigV1.TraceTailSamplingRules.DeleteTraceTailSamplingRules(req)
+	return err
+}
+
+type generatedUnstableOtelMetricsIngestion struct{}
+
+func (generatedUnstableOtelMetricsIngestion) slugOf(m *configunstablemodels.ConfigunstableOtelMetricsIngestion) string {
+	return OtelMetricsIngestionID
+}
+
+func (generatedUnstableOtelMetricsIngestion) create(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configunstablemodels.ConfigunstableOtelMetricsIngestion,
+	dryRun bool,
+) (string, error) {
+	if dryRun {
+		return "", fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &otel_metrics_ingestion.CreateOtelMetricsIngestionParams{
+		Context: ctx,
+		Body: &configunstablemodels.ConfigunstableCreateOtelMetricsIngestionRequest{
+			OtelMetricsIngestion: m,
+		},
+	}
+	resp, err := clients.ConfigUnstable.OtelMetricsIngestion.CreateOtelMetricsIngestion(req)
+	if err != nil {
+		return "", err
+	}
+	e := resp.Payload.OtelMetricsIngestion
+	if e == nil {
+		return "", nil
+	}
+	return (generatedUnstableOtelMetricsIngestion{}).slugOf(e), nil
+}
+
+func (generatedUnstableOtelMetricsIngestion) read(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) (*configunstablemodels.ConfigunstableOtelMetricsIngestion, error) {
+	req := &otel_metrics_ingestion.ReadOtelMetricsIngestionParams{
+		Context: ctx,
+	}
+	resp, err := clients.ConfigUnstable.OtelMetricsIngestion.ReadOtelMetricsIngestion(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload.OtelMetricsIngestion, nil
+}
+
+func (generatedUnstableOtelMetricsIngestion) update(
+	ctx context.Context,
+	clients apiclients.Clients,
+	m *configunstablemodels.ConfigunstableOtelMetricsIngestion,
+	params updateParams,
+) error {
+	if params.dryRun {
+		return fmt.Errorf("dry run not supported for this entity type")
+	}
+	req := &otel_metrics_ingestion.UpdateOtelMetricsIngestionParams{
+		Context: ctx,
+
+		Body: &configunstablemodels.ConfigunstableUpdateOtelMetricsIngestionRequest{
+
+			OtelMetricsIngestion: m,
+			CreateIfMissing:      params.createIfMissing,
+		},
+	}
+	_, err := clients.ConfigUnstable.OtelMetricsIngestion.UpdateOtelMetricsIngestion(req)
+	return err
+}
+func (generatedUnstableOtelMetricsIngestion) delete(
+	ctx context.Context,
+	clients apiclients.Clients,
+	slug string,
+) error {
+	req := &otel_metrics_ingestion.DeleteOtelMetricsIngestionParams{
+		Context: ctx,
+	}
+	_, err := clients.ConfigUnstable.OtelMetricsIngestion.DeleteOtelMetricsIngestion(req)
 	return err
 }

--- a/chronosphere/generated_resources.gen.go
+++ b/chronosphere/generated_resources.gen.go
@@ -1142,7 +1142,7 @@ func (generatedRecordingRule) delete(
 type generatedResourcePools struct{}
 
 func (generatedResourcePools) slugOf(m *configv1models.Configv1ResourcePools) string {
-	return ResourcePoolsConfigID
+	return "resource_pool_singleton"
 }
 
 func (generatedResourcePools) create(
@@ -1597,7 +1597,7 @@ func (generatedTraceMetricsRule) delete(
 type generatedTraceTailSamplingRules struct{}
 
 func (generatedTraceTailSamplingRules) slugOf(m *configv1models.Configv1TraceTailSamplingRules) string {
-	return TraceTailSamplingRulesID
+	return "trace_tail_sampling_singleton"
 }
 
 func (generatedTraceTailSamplingRules) create(
@@ -1677,7 +1677,7 @@ func (generatedTraceTailSamplingRules) delete(
 type generatedUnstableOtelMetricsIngestion struct{}
 
 func (generatedUnstableOtelMetricsIngestion) slugOf(m *configunstablemodels.ConfigunstableOtelMetricsIngestion) string {
-	return OtelMetricsIngestionID
+	return "otel_metrics_ingestion_singleton"
 }
 
 func (generatedUnstableOtelMetricsIngestion) create(

--- a/chronosphere/generated_resources.gen.go
+++ b/chronosphere/generated_resources.gen.go
@@ -1151,13 +1151,11 @@ func (generatedResourcePools) create(
 	m *configv1models.Configv1ResourcePools,
 	dryRun bool,
 ) (string, error) {
-	if dryRun {
-		return "", fmt.Errorf("dry run not supported for this entity type")
-	}
 	req := &resource_pools.CreateResourcePoolsParams{
 		Context: ctx,
 		Body: &configv1models.Configv1CreateResourcePoolsRequest{
 			ResourcePools: m,
+			DryRun:        dryRun,
 		},
 	}
 	resp, err := clients.ConfigV1.ResourcePools.CreateResourcePools(req)
@@ -1192,9 +1190,6 @@ func (generatedResourcePools) update(
 	m *configv1models.Configv1ResourcePools,
 	params updateParams,
 ) error {
-	if params.dryRun {
-		return fmt.Errorf("dry run not supported for this entity type")
-	}
 	req := &resource_pools.UpdateResourcePoolsParams{
 		Context: ctx,
 
@@ -1202,6 +1197,7 @@ func (generatedResourcePools) update(
 
 			ResourcePools:   m,
 			CreateIfMissing: params.createIfMissing,
+			DryRun:          params.dryRun,
 		},
 	}
 	_, err := clients.ConfigV1.ResourcePools.UpdateResourcePools(req)

--- a/chronosphere/generated_resources.gen.go
+++ b/chronosphere/generated_resources.gen.go
@@ -1141,8 +1141,11 @@ func (generatedRecordingRule) delete(
 
 type generatedResourcePools struct{}
 
+// ResourcePoolsID is the static ID of the global ResourcePools singleton.
+const ResourcePoolsID = "resource_pool_singleton"
+
 func (generatedResourcePools) slugOf(m *configv1models.Configv1ResourcePools) string {
-	return "resource_pool_singleton"
+	return ResourcePoolsID
 }
 
 func (generatedResourcePools) create(
@@ -1596,8 +1599,11 @@ func (generatedTraceMetricsRule) delete(
 
 type generatedTraceTailSamplingRules struct{}
 
+// TraceTailSamplingRulesID is the static ID of the global TraceTailSamplingRules singleton.
+const TraceTailSamplingRulesID = "trace_tail_sampling_singleton"
+
 func (generatedTraceTailSamplingRules) slugOf(m *configv1models.Configv1TraceTailSamplingRules) string {
-	return "trace_tail_sampling_singleton"
+	return TraceTailSamplingRulesID
 }
 
 func (generatedTraceTailSamplingRules) create(
@@ -1676,8 +1682,11 @@ func (generatedTraceTailSamplingRules) delete(
 
 type generatedUnstableOtelMetricsIngestion struct{}
 
+// OtelMetricsIngestionID is the static ID of the global OtelMetricsIngestion singleton.
+const OtelMetricsIngestionID = "otel_metrics_ingestion_singleton"
+
 func (generatedUnstableOtelMetricsIngestion) slugOf(m *configunstablemodels.ConfigunstableOtelMetricsIngestion) string {
-	return "otel_metrics_ingestion_singleton"
+	return OtelMetricsIngestionID
 }
 
 func (generatedUnstableOtelMetricsIngestion) create(

--- a/chronosphere/generateresources/main.go
+++ b/chronosphere/generateresources/main.go
@@ -48,12 +48,12 @@ func run() error {
 	}
 
 	var entityTypes []entityType
-	for _, e := range registry.StandardEntities(registry.V1) {
+	for _, e := range registry.AllEntities(registry.V1) {
 		entityTypes = append(entityTypes, newEntityType(v1, e))
 	}
 
 	includesUnstable := false
-	for _, e := range registry.StandardEntities(registry.Unstable) {
+	for _, e := range registry.AllEntities(registry.Unstable) {
 		entityTypes = append(entityTypes, newEntityType(unstable, e))
 		includesUnstable = true
 	}
@@ -91,6 +91,7 @@ type entityType struct {
 	SwaggerClientPackage string
 	DryRun               bool
 	UpdateUnsupported    bool
+	SingletonID          string
 }
 
 func newEntityType(a api, r registry.Resource) entityType {
@@ -103,12 +104,18 @@ func newEntityType(a api, r registry.Resource) entityType {
 		SwaggerClientPackage: strcase.ToSnake(r.Entity),
 		DryRun:               r.DryRun,
 		UpdateUnsupported:    r.UpdateUnsupported,
+		SingletonID:          r.SingletonID,
 	}
 
 	// special case for classic dashboards
 	if r.Name == "classic_dashboard" {
 		et.GoType = fmt.Sprintf("%s%s", a.GoPrefix, "ClassicDashboard")
 	}
+	// if r.Name == "resource_pools_config" {
+	// 	et.SwaggerModel = "ResourcePools"
+	// 	et.SwaggerType = "ResourcePools"
+	// 	et.SwaggerClientPackage = "resource_pools"
+	// }
 	return et
 }
 
@@ -144,14 +151,18 @@ import (
 	type {{.GoType}} struct{}
 
 func ({{.GoType}}) slugOf(m *{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}}) string {
+	{{ if .SingletonID -}}
+	return {{.SingletonID}}
+	{{- else -}}
 	return m.Slug
+	{{- end }}
 }
 
 func ({{.GoType}}) create(
 	ctx context.Context,
 	clients apiclients.Clients,
 	m *{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}},
-    dryRun bool,
+	dryRun bool,
 ) (string, error) {
 	{{ if not .DryRun -}}
 	if dryRun {
@@ -173,7 +184,7 @@ func ({{.GoType}}) create(
 	if e == nil {
 	  return "", nil
 	}
-	return e.Slug, nil
+	return ({{.GoType}}{}).slugOf(e), nil
 }
 
 func ({{.GoType}}) read(
@@ -183,7 +194,9 @@ func ({{.GoType}}) read(
 ) (*{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}}, error) {
 	req := &{{.SwaggerClientPackage}}.Read{{.SwaggerType}}Params{
 		Context: ctx,
+		{{ if not .SingletonID -}}
 		Slug:    slug,
+		{{- end }}
 	}
 	resp, err := clients.{{.SwaggerClient}}.Read{{.SwaggerType}}(req)
 	if err != nil {
@@ -206,8 +219,14 @@ func ({{.GoType}}) update(
 	{{ end -}}
 	req := &{{.SwaggerClientPackage}}.Update{{.SwaggerType}}Params{
 		Context: ctx,
+		{{ if not .SingletonID -}}
 		Slug:    m.Slug,
+		{{- end }}
+		{{ if not .SingletonID }}
 		Body: &{{.API.Package}}models.{{.API.Client}}Update{{.SwaggerType}}Body{
+		{{ else }}
+		Body: &{{.API.Package}}models.{{.API.SwaggerPrefix}}Update{{.SwaggerType}}Request{
+		{{ end }}
 			{{.SwaggerType}}: m,
 			CreateIfMissing: params.createIfMissing,
 			{{ if .DryRun }} DryRun: params.dryRun, {{ end }}
@@ -225,7 +244,9 @@ func ({{.GoType}}) delete(
 ) error {
 	req := &{{.SwaggerClientPackage}}.Delete{{.SwaggerType}}Params{
 		Context: ctx,
+		{{ if not .SingletonID -}}
 		Slug:    slug,
+		{{- end }}
 	}
 	_, err := clients.{{.SwaggerClient}}.Delete{{.SwaggerType}}(req)
 	return err

--- a/chronosphere/generateresources/main.go
+++ b/chronosphere/generateresources/main.go
@@ -143,7 +143,7 @@ import (
 
 {{ range .EntityTypes }}
 
-	type {{.GoType}} struct{}
+type {{.GoType}} struct{}
 
 func ({{.GoType}}) slugOf(m *{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}}) string {
 	{{ if .SingletonID -}}

--- a/chronosphere/generateresources/main.go
+++ b/chronosphere/generateresources/main.go
@@ -152,7 +152,7 @@ import (
 
 func ({{.GoType}}) slugOf(m *{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}}) string {
 	{{ if .SingletonID -}}
-	return {{.SingletonID}}
+	return "{{.SingletonID}}"
 	{{- else -}}
 	return m.Slug
 	{{- end }}

--- a/chronosphere/generateresources/main.go
+++ b/chronosphere/generateresources/main.go
@@ -92,6 +92,7 @@ type entityType struct {
 	DryRun               bool
 	UpdateUnsupported    bool
 	SingletonID          string
+	SingletonIDConst     string
 }
 
 func newEntityType(a api, r registry.Resource) entityType {
@@ -105,6 +106,7 @@ func newEntityType(a api, r registry.Resource) entityType {
 		DryRun:               r.DryRun,
 		UpdateUnsupported:    r.UpdateUnsupported,
 		SingletonID:          r.SingletonID,
+		SingletonIDConst:     fmt.Sprintf("%sID", r.Entity),
 	}
 
 	// special case for classic dashboards
@@ -145,9 +147,14 @@ import (
 
 type {{.GoType}} struct{}
 
+{{ if .SingletonID -}}
+// {{.SingletonIDConst}} is the static ID of the global {{.SwaggerModel}} singleton.
+const {{.SingletonIDConst}} = "{{.SingletonID}}"
+{{- end }}
+
 func ({{.GoType}}) slugOf(m *{{.API.Package}}models.{{.API.SwaggerPrefix}}{{.SwaggerModel}}) string {
 	{{ if .SingletonID -}}
-	return "{{.SingletonID}}"
+	return {{.SingletonIDConst}}
 	{{- else -}}
 	return m.Slug
 	{{- end }}

--- a/chronosphere/generateresources/main.go
+++ b/chronosphere/generateresources/main.go
@@ -111,11 +111,6 @@ func newEntityType(a api, r registry.Resource) entityType {
 	if r.Name == "classic_dashboard" {
 		et.GoType = fmt.Sprintf("%s%s", a.GoPrefix, "ClassicDashboard")
 	}
-	// if r.Name == "resource_pools_config" {
-	// 	et.SwaggerModel = "ResourcePools"
-	// 	et.SwaggerType = "ResourcePools"
-	// 	et.SwaggerClientPackage = "resource_pools"
-	// }
 	return et
 }
 

--- a/chronosphere/generic_resource.go
+++ b/chronosphere/generic_resource.go
@@ -202,6 +202,19 @@ func (r genericResource[M, SV, S]) ReadContext(
 	if err != nil {
 		return diag.Errorf(err.Error())
 	}
+
+	type normalizer interface {
+		normalize(schemaCfg, serverCfg S)
+	}
+	if nr, ok := r.converter.(normalizer); ok {
+		// Normalize the server-read value against the value set in config.
+		configured := newInternalSchema[SV, S]()
+		if err := configured.FromResourceData(d); err != nil {
+			return diag.Errorf("cannot read config from schema: %v", err)
+		}
+		nr.normalize(configured, s)
+	}
+
 	return s.ToResourceData(d)
 }
 

--- a/chronosphere/pagination/generatepagination/main.go
+++ b/chronosphere/pagination/generatepagination/main.go
@@ -49,12 +49,12 @@ func run() error {
 	}
 
 	var entityTypes []entityType
-	for _, e := range registry.StandardEntities(registry.V1) {
+	for _, e := range registry.NamedEntities(registry.V1) {
 		entityTypes = append(entityTypes, newEntityType(v1, e))
 	}
 	entityTypes = append(entityTypes, newClassicDashboard(v1))
 	includesUnstable := false
-	for _, e := range registry.StandardEntities(registry.Unstable) {
+	for _, e := range registry.NamedEntities(registry.Unstable) {
 		entityTypes = append(entityTypes, newEntityType(unstable, e))
 		includesUnstable = true
 	}

--- a/chronosphere/registry/registry.go
+++ b/chronosphere/registry/registry.go
@@ -267,7 +267,7 @@ var Resources = mustValidate([]Resource{
 		Entity:      "OtelMetricsIngestion",
 		API:         Unstable,
 		Schema:      tfschema.OtelMetricsIngestion,
-		SingletonID: "OtelMetricsIngestionID",
+		SingletonID: "otel_metrics_ingestion_singleton",
 	},
 	{
 		Name:   "pagerduty_alert_notifier",
@@ -288,7 +288,7 @@ var Resources = mustValidate([]Resource{
 		Entity:      "ResourcePools",
 		API:         V1,
 		Schema:      tfschema.ResourcePoolsConfig,
-		SingletonID: "ResourcePoolsConfigID",
+		SingletonID: "resource_pool_singleton",
 		DryRun:      true,
 	},
 	{
@@ -352,6 +352,6 @@ var Resources = mustValidate([]Resource{
 		Entity:      "TraceTailSamplingRules",
 		API:         V1,
 		Schema:      tfschema.TraceTailSamplingRules,
-		SingletonID: "TraceTailSamplingRulesID",
+		SingletonID: "trace_tail_sampling_singleton",
 	},
 })

--- a/chronosphere/registry/registry.go
+++ b/chronosphere/registry/registry.go
@@ -26,16 +26,15 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
-// StandardEntities returns all unique entity names which are registered against
-// the given api, where all resources w/ NonStandardEntity=true are filtered
-// out. Useful for generating standard CRUD+List bindings.
+// AllEntities returns all entities which are registered against the given API.
+// It includes Singletons, and is used for generating CRUD bindings.
 func AllEntities(api API) []Resource {
 	return entities(api, true /* includeSingletons */)
 }
 
-// StandardEntities returns all unique entity names which are registered against
-// the given api, where all resources w/ NonStandardEntity=true are filtered
-// out. Useful for generating standard CRUD+List bindings.
+// NamedEntities returns all entities which are registered against the given API.
+// It only includes non-singleton entities and is useful for use-cases that
+// don't make sense for singletons, such as generating List bindings.
 func NamedEntities(api API) []Resource {
 	return entities(api, false /* includeSingletons */)
 }

--- a/chronosphere/registry/registry.go
+++ b/chronosphere/registry/registry.go
@@ -289,6 +289,7 @@ var Resources = mustValidate([]Resource{
 		API:         V1,
 		Schema:      tfschema.ResourcePoolsConfig,
 		SingletonID: "ResourcePoolsConfigID",
+		DryRun:      true,
 	},
 	{
 		Name:   "rollup_rule",

--- a/chronosphere/resource_otel_metrics_ingestion.go
+++ b/chronosphere/resource_otel_metrics_ingestion.go
@@ -30,9 +30,6 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
-// OtelMetricsIngestionID is the static ID of the global OTel metrics ingestion singleton.
-const OtelMetricsIngestionID = "otel_metrics_ingestion_singleton"
-
 func resourceOtelMetricsIngestion() *schema.Resource {
 	return &schema.Resource{
 		Schema:        tfschema.OtelMetricsIngestion,

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -81,9 +81,7 @@ func (resourcePoolsConfigConverter) toModel(
 		resourcePools = r.Pools
 	}
 
-	pools, err := sliceutil.MapErr(resourcePools, func(pool intschema.ResourcePoolsConfigPool) (*apimodels.ResourcePoolsPool, error) {
-		return buildPool(pool)
-	})
+	pools, err := sliceutil.MapErr(resourcePools, buildPool)
 	if err != nil {
 		return nil, err
 	}

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -73,9 +73,9 @@ func (resourcePoolsConfigConverter) toModel(
 
 	// The resource has equivalent "pool" and deprecated "pools" lists.
 	// Only one is set at any given time and the server does not distinguish the different lists.
-	resourcePools := r.Pool
-	if len(r.Pools) > 0 {
-		resourcePools = r.Pools
+	resourcePools := r.Pools
+	if len(r.Pool) > 0 {
+		resourcePools = r.Pool
 	}
 
 	pools, err := sliceutil.MapErr(resourcePools, buildPool)

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -15,19 +15,15 @@
 package chronosphere
 
 import (
-	"context"
-	stderrors "errors"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.uber.org/atomic"
 
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/aggregationfilter"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/intschema"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/clienterror"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/resource_pools"
+	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
 	apimodels "github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/tfresource"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/sliceutil"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
@@ -36,112 +32,122 @@ import (
 const ResourcePoolsConfigID = "resource_pool_singleton"
 
 // ResourcePoolsConfigFromModel maps an API model into an intschema model.
-func ResourcePoolsConfigFromModel(m *apimodels.Configv1ResourcePools) *intschema.ResourcePoolsConfig {
-	return &intschema.ResourcePoolsConfig{
-		DefaultPool: &intschema.ResourcePoolsConfigDefaultPool{
-			Allocation: expandAllocation(m.DefaultPool.Allocation),
-			Priorities: expandPriorities(m.DefaultPool.Priorities),
-		},
-		Pool: expandPools(m.Pools),
-	}
+func ResourcePoolsConfigFromModel(m *apimodels.Configv1ResourcePools) (*intschema.ResourcePoolsConfig, error) {
+	return (resourcePoolsConfigConverter{}).fromModel(m)
 }
 
 func resourceResourcePoolsConfig() *schema.Resource {
+	r := newGenericResource[
+		*models.Configv1ResourcePools,
+		intschema.ResourcePoolsConfig,
+		*intschema.ResourcePoolsConfig,
+	](
+		"resource_pools_config",
+		resourcePoolsConfigConverter{},
+		generatedResourcePools{},
+	)
+
 	return &schema.Resource{
+		CreateContext: r.CreateContext,
+		ReadContext:   r.ReadContext,
+		UpdateContext: r.UpdateContext,
+		DeleteContext: r.DeleteContext,
 		Schema:        tfschema.ResourcePoolsConfig,
+		CustomizeDiff: r.ValidateDryRun(&ResourcePoolsConfigDryRunCount),
 		SchemaVersion: 1,
 		Description:   "Shared admin config controlling quota usage in Chronosphere",
-		CreateContext: resourceResourcePoolsConfigCreate,
-		ReadContext:   resourceResourcePoolsConfigRead,
-		UpdateContext: resourceResourcePoolsConfigUpdate,
-		DeleteContext: resourceResourcePoolsConfigDelete,
-		CustomizeDiff: resourceResourcePoolCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
 
-func resourceResourcePoolsConfigCreate(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "resource_pools_config")
-	cli := getConfigClient(meta)
+// ResourcePoolsConfigDryRunCount tracks how many times dry run is run during validation for testing.
+var ResourcePoolsConfigDryRunCount atomic.Int64
 
-	poolsConfig, err := buildResourcePoolsConfig(d)
+type resourcePoolsConfigConverter struct{}
+
+func (resourcePoolsConfigConverter) toModel(
+	r *intschema.ResourcePoolsConfig,
+) (*models.Configv1ResourcePools, error) {
+	if len(r.Pool) > 0 && len(r.Pools) > 0 {
+		return nil, fmt.Errorf("cannot set both pool and pools")
+	}
+
+	// The resource has equivalent "pool" and deprecated "pools" lists.
+	// Only one is set at any given time and the server does not distinguish the different lists.
+	resourcePools := r.Pool
+	if len(r.Pools) > 0 {
+		resourcePools = r.Pools
+	}
+
+	pools, err := sliceutil.MapErr(resourcePools, func(pool intschema.ResourcePoolsConfigPool) (*apimodels.ResourcePoolsPool, error) {
+		return buildPool(pool)
+	})
 	if err != nil {
-		return diag.Errorf("could not build resource pools config: %v", err)
+		return nil, err
 	}
-
-	req := &resource_pools.CreateResourcePoolsParams{
-		Body: &apimodels.Configv1CreateResourcePoolsRequest{
-			ResourcePools: poolsConfig,
-		},
-		Context: ctx,
+	defaultPool, err := buildDefaultPool(r.DefaultPool)
+	if err != nil {
+		return nil, err
 	}
-	if _, err = cli.ResourcePools.CreateResourcePools(req); err != nil {
-		return diag.Errorf("could not create resource pool config: %v", err)
-	}
-
-	d.SetId(ResourcePoolsConfigID)
-
-	return nil
+	return &apimodels.Configv1ResourcePools{
+		DefaultPool: defaultPool,
+		Pools:       pools,
+	}, nil
 }
 
-func resourceResourcePoolsConfigRead(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "resource_pools_config")
-	cli := getConfigClient(meta)
+func (resourcePoolsConfigConverter) fromModel(
+	m *models.Configv1ResourcePools,
+) (*intschema.ResourcePoolsConfig, error) {
+	return &intschema.ResourcePoolsConfig{
+		DefaultPool: &intschema.ResourcePoolsConfigDefaultPool{
+			Allocation: expandAllocation(m.DefaultPool.Allocation),
+			Priorities: expandPriorities(m.DefaultPool.Priorities),
+		},
+		Pool: expandPools(m.Pools),
+	}, nil
+}
 
-	resp, err := cli.ResourcePools.ReadResourcePools(&resource_pools.ReadResourcePoolsParams{Context: ctx})
-	if clienterror.IsNotFound(err) {
-		setResourceNotFound(d)
-		return nil
-	} else if err != nil {
-		return diag.Errorf("unable to read resource pools config: %v", clienterror.Wrap(err))
-	}
+type resourcePoolsResourceWrapper struct {
+	resource genericResource[
+		*models.Configv1ResourcePools,
+		intschema.ResourcePoolsConfig,
+		*intschema.ResourcePoolsConfig,
+	]
+}
 
-	serverCfg := resp.Payload.ResourcePools
-	schemaConfig := ResourcePoolsConfigFromModel(serverCfg)
-
-	// The Terraform schema has equivalent "pool" and deprecated "pools" fields that are the same on the server.
-	// Take the server config and read it into whichever field (pool or pools) that the user has decided to set.
-	// This avoids a meaningless diff being shown during "terraform plan".
-	tfConfig := &intschema.ResourcePoolsConfig{}
-	if err := tfConfig.FromResourceData(d); err != nil {
-		return diag.Errorf("reading existing config: %v", err)
-	}
-
+// The Terraform schema has equivalent "pool" and deprecated "pools" fields that are the same on the server.
+// Take the server config and read it into whichever field (pool or pools) that the user has decided to set.
+// This avoids a meaningless diff being shown during "terraform plan".
+func (resourcePoolsConfigConverter) normalize(config, server *intschema.ResourcePoolsConfig) {
 	// pick the tf pool or pools to use.
-	tfPools := tfConfig.Pool
-	if len(tfConfig.Pools) > 0 {
-		tfPools = tfConfig.Pools
+	tfPools := config.Pool
+	if len(config.Pools) > 0 {
+		tfPools = config.Pools
 	}
 
-	// index tfConfig pools by name since we may be adding or removing items
-	// in the new schema. We cannot assumt len(tfConfig.Pools) == len(schemaConfig.Pools)
+	// index config pools by name since we may be adding or removing items
+	// in the new schema. We cannot assumt len(config.Pools) == len(schemaConfig.Pools)
 	tfPoolsByName := map[string]intschema.ResourcePoolsConfigPool{}
 	for _, p := range tfPools {
 		tfPoolsByName[p.Name] = p
 	}
 
-	for i, pool := range schemaConfig.Pool {
+	for i, pool := range server.Pool {
 		if tfPool, ok := tfPoolsByName[pool.Name]; ok {
 			if tfPool.MatchRule != "" && len(pool.MatchRules) == 1 {
 				pool.MatchRule = pool.MatchRules[0]
 				pool.MatchRules = nil
-				schemaConfig.Pool[i] = pool
+				server.Pool[i] = pool
 			}
 		}
 	}
 
-	if len(tfConfig.Pools) > 0 {
-		schemaConfig.Pools = schemaConfig.Pool
-		schemaConfig.Pool = nil
+	if len(config.Pools) > 0 {
+		server.Pools = server.Pool
+		server.Pool = nil
 	}
-
-	return schemaConfig.ToResourceData(d)
 }
 
 func expandAllocation(allocation *apimodels.ResourcePoolsAllocation) *intschema.ResourcePoolAllocationSchema {
@@ -173,131 +179,6 @@ func expandPools(pools []*apimodels.ResourcePoolsPool) []intschema.ResourcePools
 			Priorities: expandPriorities(pool.Priorities),
 		}
 	})
-}
-
-func resourceResourcePoolsConfigUpdate(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "resource_pools_config")
-	cli := getConfigClient(meta)
-
-	poolsConfig, err := buildResourcePoolsConfig(d)
-	if err != nil {
-		return diag.Errorf("could not build resource pools config: %v", err)
-	}
-	req := &resource_pools.UpdateResourcePoolsParams{
-		Context: ctx,
-		Body: &apimodels.Configv1UpdateResourcePoolsRequest{
-			ResourcePools: poolsConfig,
-		},
-	}
-	_, err = cli.ResourcePools.UpdateResourcePools(req)
-	if err != nil {
-		return diag.Errorf("unable to update resource pools config: %v", err)
-	}
-	return nil
-}
-
-func resourceResourcePoolsConfigDelete(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "resource_pools_config")
-	cli := getConfigClient(meta)
-
-	req := &resource_pools.DeleteResourcePoolsParams{Context: ctx}
-	if _, err := cli.ResourcePools.DeleteResourcePools(req); clienterror.IsNotFound(err) {
-		// Ignore 404s since it means the resource is already deleted
-	} else if err != nil {
-		return diag.Errorf("unable to delete resource pool config: %v", err)
-	}
-	d.SetId("")
-
-	return nil
-}
-
-func resourceResourcePoolCustomizeDiff(
-	_ context.Context, d *schema.ResourceDiff, meta any,
-) error {
-	cfg, err := buildResourcePoolsConfig(d)
-	if err != nil {
-		return fmt.Errorf("unable to build resource pools config: %w", err)
-	}
-
-	tfConfig := &intschema.ResourcePoolsConfig{}
-	if err := tfConfig.FromResourceData(d); err != nil {
-		return fmt.Errorf("reading existing config: %v", err)
-	}
-
-	for i, pool := range tfConfig.Pools {
-		if (pool.MatchRule != "") == (len(pool.MatchRules) > 0) {
-			return fmt.Errorf("pool %d must set exactly one match_rules or match_rule", i)
-		}
-	}
-
-	return validateResourcePoolsConfig(cfg)
-}
-
-func validateResourcePoolsConfig(cfg *apimodels.Configv1ResourcePools) error {
-	sum := cfg.DefaultPool.Allocation.PercentOfLicense
-	for _, pool := range cfg.Pools {
-		sum += pool.Allocation.PercentOfLicense
-
-		if err := validateResourcePoolPriorities(pool.Priorities); err != nil {
-			return err
-		}
-	}
-	if sum != 100 {
-		return stderrors.New("total allocation must sum to 100%")
-	}
-
-	if err := validateResourcePoolPriorities(cfg.DefaultPool.Priorities); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateResourcePoolPriorities(priorities *apimodels.ResourcePoolsPriorities) error {
-	if priorities == nil {
-		return nil
-	}
-	if len(priorities.HighPriorityFilters) == 0 && len(priorities.LowPriorityFilters) == 0 {
-		return stderrors.New("priorities have at least one of high_priority_match_rules or low_priority_match_rules")
-	}
-	return nil
-}
-
-func buildResourcePoolsConfig(d ResourceGetter) (*apimodels.Configv1ResourcePools, error) {
-	config := &intschema.ResourcePoolsConfig{}
-	if err := config.FromResourceData(d); err != nil {
-		return nil, err
-	}
-
-	if len(config.Pool) > 0 && len(config.Pools) > 0 {
-		return nil, fmt.Errorf("cannot set both pool and pools")
-	}
-
-	// The resource has equivalent "pool" and deprecated "pools" lists.
-	// Only one is set at any given time and the server does not distinguish the different lists.
-	resourcePools := config.Pool
-	if len(config.Pools) > 0 {
-		resourcePools = config.Pools
-	}
-
-	pools, err := sliceutil.MapErr(resourcePools, func(pool intschema.ResourcePoolsConfigPool) (*apimodels.ResourcePoolsPool, error) {
-		return buildPool(pool)
-	})
-	if err != nil {
-		return nil, err
-	}
-	defaultPool, err := buildDefaultPool(config.DefaultPool)
-	if err != nil {
-		return nil, err
-	}
-	return &apimodels.Configv1ResourcePools{
-		DefaultPool: defaultPool,
-		Pools:       pools,
-	}, nil
 }
 
 func buildDefaultPool(defaultPool *intschema.ResourcePoolsConfigDefaultPool) (*apimodels.ResourcePoolsDefaultPool, error) {

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -28,9 +28,6 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
-// ResourcePoolsConfigID is the static ID of the global resource pools singleton.
-const ResourcePoolsConfigID = "resource_pool_singleton"
-
 // ResourcePoolsConfigFromModel maps an API model into an intschema model.
 func ResourcePoolsConfigFromModel(m *apimodels.Configv1ResourcePools) (*intschema.ResourcePoolsConfig, error) {
 	return (resourcePoolsConfigConverter{}).fromModel(m)

--- a/chronosphere/resource_trace_tail_sampling_rules.go
+++ b/chronosphere/resource_trace_tail_sampling_rules.go
@@ -30,9 +30,6 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
-// TraceTailSamplingRulesID is the static ID of the global trace tail sampling rules singleton.
-const TraceTailSamplingRulesID = "trace_tail_sampling_singleton"
-
 func resourceTraceTailSamplingRules() *schema.Resource {
 	return &schema.Resource{
 		Schema:        tfschema.TraceTailSamplingRules,


### PR DESCRIPTION
Currently, resource pools rely on client-side validation, which requires manually
keeping it in-sync with server-side validation (as in #50).

Instead, we can replace the client-side validation with server-side dry-run validation.

Instead of manually calling dry-run validation, use genericResource and generate
singleton CRUD wrappers.

Resource pools have some custom mapping from the server-side schema to the
terraform schema based on what fields are locally set (e.g., `pool` vs `pools`)
which is supported by new support in the converter to `normalize`.