### PR TITLE
Drop unused type params + methods in genericResource

### DIFF
--- a/chronosphere/generic_resource.go
+++ b/chronosphere/generic_resource.go
@@ -116,20 +116,6 @@ func newGenericResource[M any, SV any, S internalSchemaPtr[SV]](
 	}
 }
 
-type noopConverter[T any] struct{}
-
-func (noopConverter[T]) toModel(v T) (T, error)   { return v, nil }
-func (noopConverter[T]) fromModel(v T) (T, error) { return v, nil }
-
-// newNoConvertResource is used for resources that don't have a consistent model
-// across create/read/update, relying on per-endpoint intschema mapping.
-func newNoConvertResource[SV any, S internalSchemaPtr[SV]](
-	name string,
-	g generatedResource[S],
-) genericResource[S, SV, S] {
-	return newGenericResource[S, SV, S](name, noopConverter[S]{}, g)
-}
-
 // CreateContext implements schema.CreateContextFunc.
 func (r genericResource[M, SV, S]) CreateContext(
 	ctx context.Context, d *schema.ResourceData, meta any,

--- a/chronosphere/resource_blackhole_alert_notifier.go
+++ b/chronosphere/resource_blackhole_alert_notifier.go
@@ -30,11 +30,7 @@ func BlackholeAlertNotifierFromModel(
 }
 
 func resourceBlackHoleAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.BlackholeAlertNotifier,
-		*intschema.BlackholeAlertNotifier,
-	](
+	r := newGenericResource(
 		"blackhole_alert_notifier",
 		blackholeAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_bucket.go
+++ b/chronosphere/resource_bucket.go
@@ -62,11 +62,7 @@ var BucketDryRunCount atomic.Int64
 
 // resourceBucket represents a bucket and an optional default notification policy.
 func resourceBucket() *schema.Resource {
-	r := newGenericResource[
-		*configmodels.Configv1Bucket,
-		intschema.Bucket,
-		*intschema.Bucket,
-	](
+	r := newGenericResource(
 		"bucket",
 		bucketConverter{},
 		generatedBucket{},

--- a/chronosphere/resource_classic_dashboard.go
+++ b/chronosphere/resource_classic_dashboard.go
@@ -27,11 +27,7 @@ import (
 )
 
 func resourceClassicDashboard() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1GrafanaDashboard,
-		intschema.ClassicDashboard,
-		*intschema.ClassicDashboard,
-	](
+	r := newGenericResource(
 		"grafana_dashboard",
 		classicDashboardConverter{},
 		generatedClassicDashboard{},

--- a/chronosphere/resource_collection.go
+++ b/chronosphere/resource_collection.go
@@ -33,11 +33,7 @@ func CollectionFromModel(m *models.Configv1Collection) (*intschema.Collection, e
 }
 
 func resourceCollection() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Collection,
-		intschema.Collection,
-		*intschema.Collection,
-	](
+	r := newGenericResource(
 		"collection",
 		collectionConverter{},
 		generatedCollection{},

--- a/chronosphere/resource_dashboard.go
+++ b/chronosphere/resource_dashboard.go
@@ -33,11 +33,7 @@ func DashboardFromModel(m *models.Configv1Dashboard) (*intschema.Dashboard, erro
 }
 
 func resourceDashboard() *schema.Resource {
-	resource := newGenericResource[
-		*models.Configv1Dashboard,
-		intschema.Dashboard,
-		*intschema.Dashboard,
-	](
+	resource := newGenericResource(
 		"dashboard",
 		dashboardConverter{},
 		generatedDashboard{})

--- a/chronosphere/resource_dataset.go
+++ b/chronosphere/resource_dataset.go
@@ -31,11 +31,7 @@ func DatasetFromModel(m *models.Configv1Dataset) (*intschema.Dataset, error) {
 }
 
 func resourceDataset() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Dataset,
-		intschema.Dataset,
-		*intschema.Dataset,
-	]("dataset",
+	r := newGenericResource("dataset",
 		datasetConverter{},
 		generatedDataset{})
 

--- a/chronosphere/resource_derived_label.go
+++ b/chronosphere/resource_derived_label.go
@@ -31,11 +31,7 @@ func DerivedLabelFromModel(m *models.Configv1DerivedLabel) (*intschema.DerivedLa
 }
 
 func resourceDerivedLabel() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1DerivedLabel,
-		intschema.DerivedLabel,
-		*intschema.DerivedLabel,
-	](
+	r := newGenericResource(
 		"derived_label",
 		derivedLabelConverter{},
 		generatedDerivedLabel{},

--- a/chronosphere/resource_derived_metric.go
+++ b/chronosphere/resource_derived_metric.go
@@ -32,11 +32,7 @@ func DerivedMetricFromModel(m *models.Configv1DerivedMetric) (*intschema.Derived
 }
 
 func resourceDerivedMetric() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1DerivedMetric,
-		intschema.DerivedMetric,
-		*intschema.DerivedMetric,
-	](
+	r := newGenericResource(
 		"derived_metric",
 		derivedMetricConverter{},
 		generatedDerivedMetric{},

--- a/chronosphere/resource_drop_rule.go
+++ b/chronosphere/resource_drop_rule.go
@@ -30,11 +30,7 @@ func DropRuleFromModel(m *models.Configv1DropRule) (*intschema.DropRule, error) 
 }
 
 func resourceDropRule() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1DropRule,
-		intschema.DropRule,
-		*intschema.DropRule,
-	](
+	r := newGenericResource(
 		"drop_rule",
 		dropRuleConverter{},
 		generatedDropRule{},

--- a/chronosphere/resource_email_alert_notifier.go
+++ b/chronosphere/resource_email_alert_notifier.go
@@ -30,11 +30,7 @@ func EmailAlertNotifierFromModel(
 }
 
 func resourceEmailAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.EmailAlertNotifier,
-		*intschema.EmailAlertNotifier,
-	](
+	r := newGenericResource(
 		"email_alert_notifier",
 		emailAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_gcp_metrics_integration.go
+++ b/chronosphere/resource_gcp_metrics_integration.go
@@ -29,11 +29,7 @@ func GcpMetricsIntegrationFromModel(m *models.Configv1GcpMetricsIntegration) (*i
 }
 
 func resourceGcpMetricsIntegration() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1GcpMetricsIntegration,
-		intschema.GcpMetricsIntegration,
-		*intschema.GcpMetricsIntegration,
-	](
+	r := newGenericResource(
 		"gcp_metrics_integration",
 		gcpMetricsIntegrationConverter{},
 		generatedGcpMetricsIntegration{},

--- a/chronosphere/resource_mapping_rule.go
+++ b/chronosphere/resource_mapping_rule.go
@@ -34,11 +34,7 @@ func MappingRuleFromModel(m *models.Configv1MappingRule) (*intschema.MappingRule
 }
 
 func resourceMappingRule() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1MappingRule,
-		intschema.MappingRule,
-		*intschema.MappingRule,
-	](
+	r := newGenericResource(
 		"mapping_rule",
 		mappingRuleConverter{},
 		generatedMappingRule{},

--- a/chronosphere/resource_monitor.go
+++ b/chronosphere/resource_monitor.go
@@ -35,11 +35,7 @@ func MonitorFromModel(m *models.Configv1Monitor) (*intschema.Monitor, error) {
 }
 
 func resourceMonitor() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Monitor,
-		intschema.Monitor,
-		*intschema.Monitor,
-	](
+	r := newGenericResource(
 		"monitor",
 		monitorConverter{},
 		generatedMonitor{},

--- a/chronosphere/resource_notification_policy_independent.go
+++ b/chronosphere/resource_notification_policy_independent.go
@@ -30,11 +30,7 @@ func newIndependentNotificationPolicy() genericResource[
 	intschema.NotificationPolicy,
 	*intschema.NotificationPolicy,
 ] {
-	return newGenericResource[
-		*models.Configv1NotificationPolicy,
-		intschema.NotificationPolicy,
-		*intschema.NotificationPolicy,
-	](
+	return newGenericResource(
 		"notification_policy",
 		independentNotificationPolicyConverter{},
 		generatedNotificationPolicy{})

--- a/chronosphere/resource_opsgenie_alert_notifier.go
+++ b/chronosphere/resource_opsgenie_alert_notifier.go
@@ -34,11 +34,7 @@ func OpsgenieAlertNotifierFromModel(
 }
 
 func resourceOpsGenieAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.OpsgenieAlertNotifier,
-		*intschema.OpsgenieAlertNotifier,
-	](
+	r := newGenericResource(
 		"opsgenie_alert_notifier",
 		opsgenieAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_pagerduty_alert_notifier.go
+++ b/chronosphere/resource_pagerduty_alert_notifier.go
@@ -30,11 +30,7 @@ func PagerdutyAlertNotifierFromModel(
 }
 
 func resourcePagerdutyAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.PagerdutyAlertNotifier,
-		*intschema.PagerdutyAlertNotifier,
-	](
+	r := newGenericResource(
 		"pagerduty_alert_notifier",
 		pagerdutyAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_recording_rule.go
+++ b/chronosphere/resource_recording_rule.go
@@ -30,11 +30,7 @@ func RecordingRuleFromModel(m *models.Configv1RecordingRule) (*intschema.Recordi
 }
 
 func resourceRecordingRule() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1RecordingRule,
-		intschema.RecordingRule,
-		*intschema.RecordingRule,
-	](
+	r := newGenericResource(
 		"recording_rule",
 		recordingRuleConverter{},
 		generatedRecordingRule{},

--- a/chronosphere/resource_rollup_rule.go
+++ b/chronosphere/resource_rollup_rule.go
@@ -38,11 +38,7 @@ func RollupRuleFromModel(m *models.Configv1RollupRule) (*intschema.RollupRule, e
 }
 
 func resourceRollupRule() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1RollupRule,
-		intschema.RollupRule,
-		*intschema.RollupRule,
-	](
+	r := newGenericResource(
 		"rollup_rule",
 		rollupRuleConverter{},
 		generatedRollupRule{},

--- a/chronosphere/resource_slack_alert_notifier.go
+++ b/chronosphere/resource_slack_alert_notifier.go
@@ -30,11 +30,7 @@ func SlackAlertNotifierFromModel(
 }
 
 func resourceSlackAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.SlackAlertNotifier,
-		*intschema.SlackAlertNotifier,
-	](
+	r := newGenericResource(
 		"slack_alert_notifier",
 		slackAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_team.go
+++ b/chronosphere/resource_team.go
@@ -29,11 +29,7 @@ func TeamFromModel(m *models.Configv1Team) (*intschema.Team, error) {
 }
 
 func resourceTeam() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Team,
-		intschema.Team,
-		*intschema.Team,
-	](
+	r := newGenericResource(
 		"team",
 		teamConverter{},
 		generatedTeam{},

--- a/chronosphere/resource_trace_jaeger_remote_sampling_strategy.go
+++ b/chronosphere/resource_trace_jaeger_remote_sampling_strategy.go
@@ -29,11 +29,7 @@ func TraceJaegerRemoteSamplingStrategyFromModel(
 }
 
 func resourceTraceJRSStrategy() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1TraceJaegerRemoteSamplingStrategy,
-		intschema.TraceJaegerRemoteSamplingStrategy,
-		*intschema.TraceJaegerRemoteSamplingStrategy,
-	](
+	r := newGenericResource(
 		"trace_jaeger_remote_sampling_strategy",
 		traceJRSConverter{},
 		generatedTraceJaegerRemoteSamplingStrategy{},

--- a/chronosphere/resource_trace_metrics_rule.go
+++ b/chronosphere/resource_trace_metrics_rule.go
@@ -25,11 +25,7 @@ import (
 )
 
 func resourceTraceMetricsRule() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1TraceMetricsRule,
-		intschema.TraceMetricsRule,
-		*intschema.TraceMetricsRule,
-	](
+	r := newGenericResource(
 		"trace_metrics_rule",
 		traceMetricsRuleConverter{},
 		generatedTraceMetricsRule{},

--- a/chronosphere/resource_victorops_alert_notifier.go
+++ b/chronosphere/resource_victorops_alert_notifier.go
@@ -30,11 +30,7 @@ func VictoropsAlertNotifierFromModel(
 }
 
 func resourceVictorOpsAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.VictoropsAlertNotifier,
-		*intschema.VictoropsAlertNotifier,
-	](
+	r := newGenericResource(
 		"victorops_alert_notifier",
 		victoropsAlertNotifierConverter{},
 		generatedNotifier{},

--- a/chronosphere/resource_webhook_alert_notifier.go
+++ b/chronosphere/resource_webhook_alert_notifier.go
@@ -30,11 +30,7 @@ func WebhookAlertNotifierFromModel(
 }
 
 func resourceWebhookAlertNotifier() *schema.Resource {
-	r := newGenericResource[
-		*models.Configv1Notifier,
-		intschema.WebhookAlertNotifier,
-		*intschema.WebhookAlertNotifier,
-	](
+	r := newGenericResource(
 		"webhook_alert_notifier",
 		webhookAlertNotifierConverter{},
 		generatedNotifier{},


### PR DESCRIPTION
Newer versions of Go are able to infer the type parameters, so we can simplify and drop these.

This also drops newNoConvertResource which is unused.