### PR TITLE
Use genericResource for TraceTailSamplingRules

### DIFF
--- a/chronosphere/generated_resources.gen.go
+++ b/chronosphere/generated_resources.gen.go
@@ -1612,13 +1612,11 @@ func (generatedTraceTailSamplingRules) create(
 	m *configv1models.Configv1TraceTailSamplingRules,
 	dryRun bool,
 ) (string, error) {
-	if dryRun {
-		return "", fmt.Errorf("dry run not supported for this entity type")
-	}
 	req := &trace_tail_sampling_rules.CreateTraceTailSamplingRulesParams{
 		Context: ctx,
 		Body: &configv1models.Configv1CreateTraceTailSamplingRulesRequest{
 			TraceTailSamplingRules: m,
+			DryRun:                 dryRun,
 		},
 	}
 	resp, err := clients.ConfigV1.TraceTailSamplingRules.CreateTraceTailSamplingRules(req)
@@ -1653,9 +1651,6 @@ func (generatedTraceTailSamplingRules) update(
 	m *configv1models.Configv1TraceTailSamplingRules,
 	params updateParams,
 ) error {
-	if params.dryRun {
-		return fmt.Errorf("dry run not supported for this entity type")
-	}
 	req := &trace_tail_sampling_rules.UpdateTraceTailSamplingRulesParams{
 		Context: ctx,
 
@@ -1663,6 +1658,7 @@ func (generatedTraceTailSamplingRules) update(
 
 			TraceTailSamplingRules: m,
 			CreateIfMissing:        params.createIfMissing,
+			DryRun:                 params.dryRun,
 		},
 	}
 	_, err := clients.ConfigV1.TraceTailSamplingRules.UpdateTraceTailSamplingRules(req)

--- a/chronosphere/registry/registry.go
+++ b/chronosphere/registry/registry.go
@@ -353,5 +353,6 @@ var Resources = mustValidate([]Resource{
 		API:         V1,
 		Schema:      tfschema.TraceTailSamplingRules,
 		SingletonID: "trace_tail_sampling_singleton",
+		DryRun:      true,
 	},
 })

--- a/chronosphere/resource_trace_tail_sampling_rules.go
+++ b/chronosphere/resource_trace_tail_sampling_rules.go
@@ -15,40 +15,44 @@
 package chronosphere
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.uber.org/atomic"
 
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/intschema"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/clienterror"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/client/trace_tail_sampling_rules"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/tfresource"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/sliceutil"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
 func resourceTraceTailSamplingRules() *schema.Resource {
+	r := newGenericResource(
+		"trace_tail_sampling_rules",
+		traceTailSamplingRulesConverter{},
+		generatedTraceTailSamplingRules{},
+	)
 	return &schema.Resource{
 		Schema:        tfschema.TraceTailSamplingRules,
-		CreateContext: resourceTraceTailSamplingRulesCreate,
-		ReadContext:   resourceTraceTailSamplingRulesRead,
-		UpdateContext: resourceTraceTailSamplingRulesUpdate,
-		DeleteContext: resourceTraceTailSamplingRulesDelete,
-		CustomizeDiff: resourceTraceTailSamplingRulesCustomizeDiff,
+		CreateContext: r.CreateContext,
+		ReadContext:   r.ReadContext,
+		UpdateContext: r.UpdateContext,
+		DeleteContext: r.DeleteContext,
+		CustomizeDiff: r.ValidateDryRun(&TraceTailSamplingRulesDryRunCount),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
 
+// TraceTailSamplingRulesDryRunCount tracks how many times dry run is run during validation for testing.
+var TraceTailSamplingRulesDryRunCount atomic.Int64
+
+type traceTailSamplingRulesConverter struct{}
+
 // -----
 // toModel and related helpers.
 // -----
 
-func toModel(
+func (traceTailSamplingRulesConverter) toModel(
 	m *intschema.TraceTailSamplingRules,
 ) (*models.Configv1TraceTailSamplingRules, error) {
 	spanFilters, err := sliceutil.MapErr(m.Rules, ruleToModel)
@@ -86,13 +90,13 @@ func ruleToModel(r intschema.TraceTailSamplingRulesRules) (*models.Configv1Trace
 // fromModel and related helpers.
 // -----
 
-func fromModel(
+func (traceTailSamplingRulesConverter) fromModel(
 	m *models.Configv1TraceTailSamplingRules,
-) *intschema.TraceTailSamplingRules {
+) (*intschema.TraceTailSamplingRules, error) {
 	return &intschema.TraceTailSamplingRules{
 		DefaultSampleRate: defaultSampleRateFromModel(m.DefaultSampleRate),
 		Rules:             sliceutil.Map(m.Rules, ruleFromModel),
-	}
+	}, nil
 }
 
 func defaultSampleRateFromModel(
@@ -116,128 +120,4 @@ func ruleFromModel(
 		SystemName: r.SystemName,
 		Name:       r.Name,
 	}
-}
-
-func resourceTraceTailSamplingRulesCreate(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "trace_tail_sampling_rules")
-	cli := getConfigClient(meta)
-
-	rules, err := buildTraceTailSamplingRules(d)
-	if err != nil {
-		return diag.Errorf("could not build trace tail sampling rules: %v", err)
-	}
-	req := &trace_tail_sampling_rules.CreateTraceTailSamplingRulesParams{
-		Body: &models.Configv1CreateTraceTailSamplingRulesRequest{
-			TraceTailSamplingRules: rules,
-		},
-		Context: ctx,
-	}
-
-	if _, err := cli.TraceTailSamplingRules.CreateTraceTailSamplingRules(req); err != nil {
-		return diag.Errorf("could not create trace tail sampling rules: %v", err)
-	}
-
-	d.SetId(TraceTailSamplingRulesID)
-
-	return nil
-}
-
-func resourceTraceTailSamplingRulesRead(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "trace_tail_sampling_rules")
-	cli := getConfigClient(meta)
-
-	resp, err := cli.TraceTailSamplingRules.ReadTraceTailSamplingRules(&trace_tail_sampling_rules.ReadTraceTailSamplingRulesParams{Context: ctx})
-	if clienterror.IsNotFound(err) {
-		setResourceNotFound(d)
-		return nil
-	} else if err != nil {
-		return diag.Errorf("unable to read trace tail sampling rules: %v", clienterror.Wrap(err))
-	}
-
-	rules := resp.Payload.TraceTailSamplingRules
-	schemaRules := fromModel(rules)
-
-	if err := schemaRules.ToResourceData(d); err != nil {
-		return err
-	}
-	d.SetId(TraceTailSamplingRulesID)
-	return nil
-}
-
-func resourceTraceTailSamplingRulesUpdate(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "trace_tail_sampling_rules")
-	cli := getConfigClient(meta)
-
-	rules, err := buildTraceTailSamplingRules(d)
-	if err != nil {
-		return diag.Errorf("could not build trace tail sampling rules: %v", err)
-	}
-	req := &trace_tail_sampling_rules.UpdateTraceTailSamplingRulesParams{
-		Context: ctx,
-		Body: &models.Configv1UpdateTraceTailSamplingRulesRequest{
-			TraceTailSamplingRules: rules,
-		},
-	}
-	if _, err := cli.TraceTailSamplingRules.UpdateTraceTailSamplingRules(req); err != nil {
-		return diag.Errorf("unable to update trace tail sampling rules: %v", err)
-	}
-	return nil
-}
-
-func resourceTraceTailSamplingRulesDelete(
-	ctx context.Context, d *schema.ResourceData, meta any,
-) diag.Diagnostics {
-	ctx = tfresource.NewContext(ctx, "trace_tail_sampling_rules")
-	cli := getConfigClient(meta)
-
-	req := &trace_tail_sampling_rules.DeleteTraceTailSamplingRulesParams{Context: ctx}
-	if _, err := cli.TraceTailSamplingRules.DeleteTraceTailSamplingRules(req); clienterror.IsNotFound(err) {
-		setResourceNotFound(d)
-		return nil
-	} else if err != nil {
-		return diag.Errorf("unable to delete trace tail sampling rules: %v", err)
-	}
-
-	d.SetId("")
-
-	return nil
-}
-
-func resourceTraceTailSamplingRulesCustomizeDiff(
-	_ context.Context, d *schema.ResourceDiff, meta any,
-) error {
-	rules, err := buildTraceTailSamplingRules(d)
-	if err != nil {
-		return fmt.Errorf("unable to build trace tail sampling rules: %w", err)
-	}
-	return validateTraceTailSamplingRules(rules)
-}
-
-func validateTraceTailSamplingRules(rules *models.Configv1TraceTailSamplingRules) error {
-	for _, r := range rules.Rules {
-		if r.SampleRate < 0 || r.SampleRate > 1.0 {
-			return fmt.Errorf("expected sample rate to be a float from 0 to 1.0 inclusive, got %f", r.SampleRate)
-		}
-	}
-
-	if rules.DefaultSampleRate.SampleRate < 0 || rules.DefaultSampleRate.SampleRate > 1.0 {
-		return fmt.Errorf("expected sample rate to be a float from 0 to 1.0 inclusive, got %f", rules.DefaultSampleRate.SampleRate)
-	}
-
-	return nil
-}
-
-func buildTraceTailSamplingRules(d ResourceGetter) (*models.Configv1TraceTailSamplingRules, error) {
-	rules := &intschema.TraceTailSamplingRules{}
-	if err := rules.FromResourceData(d); err != nil {
-		return nil, err
-	}
-
-	return toModel(rules)
 }


### PR DESCRIPTION
Simplify the Otel resource by relying on genericResource support for singletons added in #51.

This replaces the custom validation with ValidateDryRun which similarly tries to convert the scheam to an API model, but also triggers a dry-run update call to validate the entity.