### PR TITLE
log_allocation_config: Fix dataset reference

### DIFF
--- a/chronosphere/intschema/generateintschema/main.go
+++ b/chronosphere/intschema/generateintschema/main.go
@@ -84,6 +84,7 @@ var fieldIsTFID = map[string]bool{
 	"execution_group":          true,
 	"notification_policy_data": true,
 	"action_ids":               true,
+	"dataset_id":               true,
 
 	"callback_id": false,
 	"external_id": false,

--- a/chronosphere/intschema/log_allocation_config.go
+++ b/chronosphere/intschema/log_allocation_config.go
@@ -60,7 +60,7 @@ type LogAllocationConfigDefaultDataset struct {
 }
 
 type LogAllocationConfigDatasetAllocation struct {
-	DatasetSlug string                     `intschema:"dataset_slug"`
-	Allocation  *LogAllocationConfigSchema `intschema:"allocation,optional,list_encoded_object"`
-	Priorities  *LogPrioritiesSchema       `intschema:"priorities,optional,list_encoded_object"`
+	DatasetId  tfid.ID                    `intschema:"dataset_id"`
+	Allocation *LogAllocationConfigSchema `intschema:"allocation,optional,list_encoded_object"`
+	Priorities *LogPrioritiesSchema       `intschema:"priorities,optional,list_encoded_object"`
 }

--- a/chronosphere/tfschema/log_allocation_config.go
+++ b/chronosphere/tfschema/log_allocation_config.go
@@ -27,7 +27,7 @@ var LogAllocationConfig = map[string]*schema.Schema{
 
 var LogDatasetAllocationSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"dataset_slug": {
+		"dataset_id": {
 			Type:     schema.TypeString,
 			Required: true,
 		},

--- a/examples/log-allocation-config/main.tf
+++ b/examples/log-allocation-config/main.tf
@@ -14,7 +14,7 @@ resource "chronosphere_log_allocation_config" "my_log_allocation_config" {
   }
 
   dataset_allocation {
-    dataset_slug = chronosphere_dataset.example_logs_dataset.slug
+    dataset_id = chronosphere_dataset.example_logs_dataset.id
     allocation {
       percent_of_license = 9.9
     }


### PR DESCRIPTION
The TF ecosystem uses `_id` fields for references to other objects. intschema also relies on the `_id` suffix to generate a field as a `tfid.ID`, allowing tests to use references.

We also need to handle dry-run validation when using a reference as the ID isn't known at plan time if it hasn't been created, so we replace it with a dummy value.

Note: This entity is still unstable, so this is not a breaking change.