### PR TITLE
slack: Don't require action_confirm_text in action [sc-111195]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fixed:
+ * Allow creating `chronosphere_slack_notifier` with actions without `action_confirm_text`.
+
 ## v1.5.0
 
 Added:

--- a/chronosphere/resource_slack_alert_notifier.go
+++ b/chronosphere/resource_slack_alert_notifier.go
@@ -145,21 +145,32 @@ func slackActionsToModel(
 	var out []*models.NotifierSlackConfigAction
 	for _, a := range actions {
 		out = append(out, &models.NotifierSlackConfigAction{
-			ConfirmField: &models.SlackConfigConfirmationField{
-				DismissText: a.ActionConfirmDismissText,
-				OkText:      a.ActionConfirmOkText,
-				Text:        a.ActionConfirmText,
-				Title:       a.ActionConfirmTile,
-			},
-			Name:  a.Name,
-			Style: a.Style,
-			Text:  a.Text,
-			Type:  a.Type,
-			URL:   a.Url,
-			Value: a.Value,
+			ConfirmField: slackConfirmFieldToModel(a),
+			Name:         a.Name,
+			Style:        a.Style,
+			Text:         a.Text,
+			Type:         a.Type,
+			URL:          a.Url,
+			Value:        a.Value,
 		})
 	}
 	return out
+}
+
+func slackConfirmFieldToModel(a intschema.SlackAlertNotifierAction) *models.SlackConfigConfirmationField {
+	cf := models.SlackConfigConfirmationField{
+		DismissText: a.ActionConfirmDismissText,
+		OkText:      a.ActionConfirmOkText,
+		Text:        a.ActionConfirmText,
+		Title:       a.ActionConfirmTile,
+	}
+
+	// Only return a confirmation if there's a non-empty Confirm field.
+	// If none of the confirm fields are set, then don't add a confirmation.
+	if cf != (models.SlackConfigConfirmationField{}) {
+		return &cf
+	}
+	return nil
 }
 
 func slackActionsFromModel(


### PR DESCRIPTION
[sc-111195]

Slack actions without `action_confirm_text` fail to create currently
as the TF model flattens confirmation fields into the action, and
always sends a non-nil confirmation field (though it may be empty).

Only set `ConfirmField` if it contains non-empty values.