### PR TITLE
tfschema: Fix rollup/mapping rule interval diff after apply [sc-111204]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Fixed:
  * Allow creating `chronosphere_slack_notifier` with actions without `action_confirm_text`.
+ * Fix `chronosphere_rollup_rule` and `chronosphere_mapping_rule` diff after applying
+   a rule without an interval or storage policy.
 
 ## v1.5.0
 

--- a/chronosphere/intschema/mapping_rule.go
+++ b/chronosphere/intschema/mapping_rule.go
@@ -21,7 +21,7 @@ type MappingRule struct {
 	Aggregations  []string                  `intschema:"aggregations,optional"`
 	Drop          bool                      `intschema:"drop,optional,default:false"`
 	DropTimestamp bool                      `intschema:"drop_timestamp,optional,default:false"`
-	Interval      string                    `intschema:"interval,optional"`
+	Interval      string                    `intschema:"interval,optional,computed"`
 	Mode          string                    `intschema:"mode,optional"`
 	StoragePolicy *MappingRuleStoragePolicy `intschema:"storage_policy,optional,list_encoded_object"`
 

--- a/chronosphere/intschema/rollup_rule.go
+++ b/chronosphere/intschema/rollup_rule.go
@@ -24,7 +24,7 @@ type RollupRule struct {
 	ExcludeBy           []string                       `intschema:"exclude_by,optional"`
 	GraphiteLabelPolicy *RollupRuleGraphiteLabelPolicy `intschema:"graphite_label_policy,optional,list_encoded_object"`
 	GroupBy             []string                       `intschema:"group_by,optional"`
-	Interval            string                         `intschema:"interval,optional"`
+	Interval            string                         `intschema:"interval,optional,computed"`
 	MetricTypeTag       bool                           `intschema:"metric_type_tag,optional,default:false"`
 	Mode                string                         `intschema:"mode,optional"`
 	NewMetric           string                         `intschema:"new_metric,optional"`

--- a/chronosphere/intschema/rollup_rule.go
+++ b/chronosphere/intschema/rollup_rule.go
@@ -29,7 +29,7 @@ type RollupRule struct {
 	Mode                string                         `intschema:"mode,optional"`
 	NewMetric           string                         `intschema:"new_metric,optional"`
 	Permissive          bool                           `intschema:"permissive,optional,default:false"`
-	StoragePolicies     *RollupRuleStoragePolicies     `intschema:"storage_policies,optional,computed,list_encoded_object"`
+	StoragePolicies     *RollupRuleStoragePolicies     `intschema:"storage_policies,optional,list_encoded_object"`
 
 	// Internal identifier used in the .state file, i.e. ResourceData.Id().
 	// Cannot be set, else ToResourceData will panic.

--- a/chronosphere/resource_rollup_rule.go
+++ b/chronosphere/resource_rollup_rule.go
@@ -73,7 +73,7 @@ func (rollupRuleConverter) toModel(
 	// which will send the last server-returned value even if the user doesn't have it set
 	// in the configuration. Hence we clear it manually to workaround sc-81013.
 	if r.Interval != "" && r.StoragePolicies != nil {
-		r.StoragePolicies = nil
+		r.Interval = ""
 	}
 
 	filter, err := aggregationfilter.StringToModel(r.Filter, aggregationfilter.RollupRuleDelimiter)

--- a/chronosphere/tfschema/mapping_rule.go
+++ b/chronosphere/tfschema/mapping_rule.go
@@ -78,6 +78,8 @@ var MappingRule = map[string]*schema.Schema{
 	"interval": {
 		Type:     schema.TypeString,
 		Optional: true,
+		// When no interval is specified, a server-side default is used.
+		Computed: true,
 	},
 	"mode": Enum{
 		Value:    enum.MappingModeType.ToStrings(),

--- a/chronosphere/tfschema/mapping_rule.go
+++ b/chronosphere/tfschema/mapping_rule.go
@@ -79,7 +79,8 @@ var MappingRule = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 		// When no interval is specified, a server-side default is used.
-		Computed: true,
+		Computed:      true,
+		ConflictsWith: []string{"storage_policy"},
 	},
 	"mode": Enum{
 		Value:    enum.MappingModeType.ToStrings(),

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -66,8 +66,6 @@ var RollupRule = map[string]*schema.Schema{
 				}.Schema(),
 			},
 		},
-		// When no policies are specified, the server-side will set the defaults.
-		Computed:   true,
 		Deprecated: "use `interval` instead",
 	},
 	"interval": {

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -71,8 +71,10 @@ var RollupRule = map[string]*schema.Schema{
 		Deprecated: "use `interval` instead",
 	},
 	"interval": {
-		Type:          schema.TypeString,
-		Optional:      true,
+		Type:     schema.TypeString,
+		Optional: true,
+		// When no interval is specified, a server-side default is used.
+		Computed:      true,
 		ConflictsWith: []string{"storage_policies"},
 	},
 	"group_by": {


### PR DESCRIPTION
[sc-111204]

When neither interval or storage_policy is specified, a server-side
default is returned. This causes a diff-after-apply, so mark the field
as computed.

Note: When using a computed field, if the user sets an explicitly value,
say `interval=60s`, and then removes that field, Terraform cannot
differentiate whether the value in the state is a server-side default or
previously set, and will continue to use the existing value as-is.
See https://github.com/hashicorp/terraform-plugin-sdk/issues/282