### PR TITLE
Add make targets to build and install snapshots for testing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,9 @@ signs:
       - "${artifact}"
 release:
   disable: true
+  draft: true
+  replace_existing_draft: true
+  replace_existing_artifacts: true
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/scripts/increment_minor.sh
+++ b/scripts/increment_minor.sh
@@ -23,20 +23,8 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-VERSION=$(git describe --abbrev=0 --tags)
-
-# Remove leading "v" from version tag (for details, see the "Substring Extraction" section of
-# https://www.tldp.org/LDP/abs/html/string-manipulation.html).
-VERSION="${VERSION:1}"
-
-# Replace "." with a space so we can split the version into an array.
-read -r -a VERSION_BITS <<<"${VERSION//./ }"
-
-MAJOR_VERSION=${VERSION_BITS[0]}
-MINOR_VERSION=${VERSION_BITS[1]}
-MINOR_VERSION=$((MINOR_VERSION + 1))
-
-NEW_VERSION="v${MAJOR_VERSION}.${MINOR_VERSION}.0"
+NEXT_VERSION_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/next_version.sh"
+NEW_VERSION=$(bash $NEXT_VERSION_SCRIPT)
 
 # Get the current hash and see if it already has a tag. We will only create the new tag if the
 # current hash does not already have a tag.

--- a/scripts/increment_patch.sh
+++ b/scripts/increment_patch.sh
@@ -23,21 +23,8 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-VERSION=$(git describe --abbrev=0 --tags)
-
-# Remove leading "v" from version tag (for details, see the "Substring Extraction" section of
-# https://www.tldp.org/LDP/abs/html/string-manipulation.html).
-VERSION="${VERSION:1}"
-
-# Replace "." with a space so we can split the version into an array.
-read -r -a VERSION_BITS <<<"${VERSION//./ }"
-
-MAJOR_VERSION=${VERSION_BITS[0]}
-MINOR_VERSION=${VERSION_BITS[1]}
-PATCH_VERSION=${VERSION_BITS[2]}
-PATCH_VERSION=$((PATCH_VERSION + 1))
-
-NEW_VERSION="v${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
+NEXT_VERSION_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/next_version.sh"
+NEW_VERSION=$(bash $NEXT_VERSION_SCRIPT --patch)
 
 # Get the current hash and see if it already has a tag. We will only create the new tag if the
 # current hash does not already have a tag.

--- a/scripts/next_version.sh
+++ b/scripts/next_version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# This script is used to generate a new release tag that is 1 minor or patch version greater than the most
+# recent release. Adapted from https://stackoverflow.com/questions/3760086/automatic-tagging-of-releases.
+patch_version=false
+for arg in "$@"; do
+    case $arg in
+    --patch | -p)
+        patch_version=true
+        shift # Remove --patch or -p from the arguments
+        ;;
+    esac
+done
+
+VERSION=$(git describe --abbrev=0 --tags)
+
+# Remove leading "v" from version tag (for details, see the "Substring Extraction" section of
+# https://www.tldp.org/LDP/abs/html/string-manipulation.html).
+VERSION="${VERSION:1}"
+
+# Replace "." with a space so we can split the version into an array.
+read -r -a VERSION_BITS <<<"${VERSION//./ }"
+
+MAJOR_VERSION=${VERSION_BITS[0]}
+MINOR_VERSION=${VERSION_BITS[1]}
+PATCH_VERSION=${VERSION_BITS[2]:0}
+
+# Increment the minor version if --patch is not set
+if [ "$patch_version" = false ]; then
+    MINOR_VERSION=$((MINOR_VERSION + 1))
+else
+    PATCH_VERSION=$((PATCH_VERSION + 1))
+fi
+
+NEW_VERSION="v${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
+
+echo ${NEW_VERSION}

--- a/scripts/run_goreleaser.sh
+++ b/scripts/run_goreleaser.sh
@@ -3,6 +3,17 @@
 set -euo pipefail
 [[ -z ${DEBUG:-} ]] || set -o xtrace
 
+# allow the script to run goreleaser release or build
+command="release"
+for arg in "$@"; do
+    case $arg in
+    --build)
+        command="build"
+        shift # Remove --build from the arguments
+        ;;
+    esac
+done
+
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 DIR="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && cd .. && pwd -P)"
 GITCONFIG_VOLUME=${GIT_CONFIG:-"${HOME}/.gitconfig"}
@@ -48,4 +59,4 @@ if [[ "${BUILDKITE:-}" != "true" ]]; then
 fi
 
 # N.B. The GO_RELEASER_DOCKER_IMAGE is expected to be set by CI.
-docker run "${DOCKER_OPTS[@]}" "${GO_RELEASER_DOCKER_IMAGE}" release "$@"
+docker run "${DOCKER_OPTS[@]}" "${GO_RELEASER_DOCKER_IMAGE}" ${command} "$@"


### PR DESCRIPTION
This PR adds make targets for installing snapshots of the terraform provider for testing with a real version number instead of using the `0.0.1-dev` strategy we have been using up until now.