### PR TITLE
Allow unowned notification policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Added:
+ * Allow `chronosphere_notification_policy` resources without a `team_id`.
+
 ## v1.5.1
 
 Fixed:


### PR DESCRIPTION
Allows creation of unowned notification policies and in-place updates to remove an owner from an existing policy.

Scenario test build 24 completed successfully.