### PR TITLE
resource-pools: Fix handling when default is unset [sc-116346]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fixed:
+* Fix `chronosphere_resource_pools_config` error when default pool is not set.
+
 ## v1.6.0
 
 Added:

--- a/chronosphere/resource_resource_pools_config.go
+++ b/chronosphere/resource_resource_pools_config.go
@@ -100,16 +100,15 @@ func (resourcePoolsConfigConverter) fromModel(
 	if err != nil {
 		return nil, err
 	}
-	allocation, err := expandAllocation(m.DefaultPool.Allocation)
+
+	defaultPool, err := expandDefaultPool(m.DefaultPool)
 	if err != nil {
 		return nil, err
 	}
+
 	return &intschema.ResourcePoolsConfig{
-		DefaultPool: &intschema.ResourcePoolsConfigDefaultPool{
-			Allocation: allocation,
-			Priorities: expandPriorities(m.DefaultPool.Priorities),
-		},
-		Pool: pools,
+		DefaultPool: defaultPool,
+		Pool:        pools,
 	}, nil
 }
 
@@ -220,6 +219,20 @@ func expandPools(pools []*apimodels.ResourcePoolsPool) ([]intschema.ResourcePool
 			Priorities: expandPriorities(pool.Priorities),
 		}, nil
 	})
+}
+
+func expandDefaultPool(d *models.ResourcePoolsDefaultPool) (*intschema.ResourcePoolsConfigDefaultPool, error) {
+	if d == nil {
+		return nil, nil
+	}
+	allocation, err := expandAllocation(d.Allocation)
+	if err != nil {
+		return nil, err
+	}
+	return &intschema.ResourcePoolsConfigDefaultPool{
+		Allocation: allocation,
+		Priorities: expandPriorities(d.Priorities),
+	}, nil
 }
 
 func buildDefaultPool(defaultPool *intschema.ResourcePoolsConfigDefaultPool) (*apimodels.ResourcePoolsDefaultPool, error) {


### PR DESCRIPTION
When `default_pool` is unset, the conversion from tf schema to model
succeeds, and the config is applied, but when converting the server
model to intshema, it fails as a `nil` default pool is not handled.