### PR TITLE
[sc-118429] Don't convert empty monitor conditions back to API model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Added:
 - Implemented support for signal grouping in the `chronosphere_slo` resource.
 
+Fixed:
+- Fixed a bug where an empty `chronosphere_monitor` condition stored in state caused failures when applying changes in our Pulumi Provider.
+
 ## v1.6.1
 
 Added:

--- a/chronosphere/resource_monitor.go
+++ b/chronosphere/resource_monitor.go
@@ -385,11 +385,9 @@ func monitorConditionsToModel(
 		}
 	}
 
-	crit := load(critical)
-	warn := load(warn)
 	return &models.SeriesConditionsSeverityConditions{
-		Critical: crit,
-		Warn:     warn,
+		Critical: load(critical),
+		Warn:     load(warn),
 	}, nil
 }
 

--- a/chronosphere/resource_monitor.go
+++ b/chronosphere/resource_monitor.go
@@ -351,7 +351,11 @@ func monitorConditionsToModel(
 	}
 
 	bySev := make(map[string][]*models.MonitorCondition)
+	var emptyVal intschema.MonitorSeriesCondition
 	for _, c := range conds {
+		if c == emptyVal {
+			continue
+		}
 		if err := checkSeverity(c.Severity); err != nil {
 			return nil, err
 		}
@@ -381,9 +385,11 @@ func monitorConditionsToModel(
 		}
 	}
 
+	crit := load(critical)
+	warn := load(warn)
 	return &models.SeriesConditionsSeverityConditions{
-		Critical: load(critical),
-		Warn:     load(warn),
+		Critical: crit,
+		Warn:     warn,
 	}, nil
 }
 


### PR DESCRIPTION
Our Pulumi provider is built using Pulumi's Terraform
bridge library. We ran into a bug specific to Pulumi where
updating the conditions of a monitor after it had been
created caused validation to fail before we even got
calling the API. The issue was trivially reproducible
in Pulumi, but non-reproducible with the same
configuration in Terraform. Upon debugging I found
that the code that converts monitor condition state
representation to the API model format was getting
an empty condition. This shouldn't happen if the
monitor was successfully applied in the past and
stored to state.

The fix I made was to ignore condition args that
are fully empty (no op, no value, no severity, etc)

I believe that this is a result of the
difference in how Terraform and Pulumi persist state.

sc-118429