### PR TITLE
Fix recording-rule dry-run when bucket/group are set [sc-125838]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Added:
 * Add v1 `chronosphere_logging_allocation_config` resource
 * Add support for `is_root_span` field in common trace span filter type.
 
+Fixed:
+* Fix dry-run for `chronosphere_recording_rule` with `bucket_slug` and `execution_group`.
+
 ## 1.6.2
 
 Added:

--- a/chronosphere/resource_log_allocation_config.go
+++ b/chronosphere/resource_log_allocation_config.go
@@ -52,7 +52,7 @@ func resourceLogAllocationConfig() *schema.Resource {
 				ModifyAPIModel: func(cfg *models.Configv1LogAllocationConfig) {
 					for _, alloc := range cfg.DatasetAllocations {
 						if alloc.DatasetSlug == "" {
-							alloc.DatasetSlug = "dummy_value"
+							alloc.DatasetSlug = dryRunUnknownRef.Slug()
 						}
 					}
 				},

--- a/chronosphere/resource_notification_policy.go
+++ b/chronosphere/resource_notification_policy.go
@@ -257,11 +257,11 @@ func (npr *notificationPolicyResourceMeta) resourceNotificationPolicyCustomizeDi
 			if !isNotificationPolicyIndependentForCustomizeDiff(diff, policy) {
 				// If the policy is inline, we want to populate required fields that are inherited from
 				// the bucket normally (name, bucket_slug). Otherwise, the API rejects the missing fields.
-				apiPolicy.BucketSlug = dummyRef.Slug()
-				apiPolicy.Name = dummyRef.Slug()
+				apiPolicy.BucketSlug = dryRunUnknownRef.Slug()
+				apiPolicy.Name = dryRunUnknownRef.Slug()
 
 				// Inline policies don't have a slug, but use a dummy slug since it's required for Update.
-				apiPolicy.Slug = dummyRef.Slug()
+				apiPolicy.Slug = dryRunUnknownRef.Slug()
 			}
 		},
 	}

--- a/chronosphere/set_unknown.go
+++ b/chronosphere/set_unknown.go
@@ -32,9 +32,9 @@ const (
 	listEncodedPath = "[0]"
 )
 
-// dummyRef is used in dry run validation to populate fields that reference other entities
-// that don't exist yet.
-var dummyRef = tfid.Slug("dummy_value")
+// dryRunUnknownRef is used as the value for reference fields that are set in config
+// but are not yet known yet as they need to be created for their ID to be known.
+var dryRunUnknownRef = tfid.Slug("dry_run_unknown")
 
 type setUnknownParams struct {
 	rawConfig      cty.Value // required
@@ -135,7 +135,7 @@ func (p setUnknownParams) setID(v reflect.Value, id tfid.ID, path []string) {
 	// same apply operation, so we set the field to a dummy value.
 	hasConfig := !p.lookupRaw(path).IsNull()
 	if id == (tfid.ID{}) && hasConfig {
-		v.Set(reflect.ValueOf(dummyRef))
+		v.Set(reflect.ValueOf(dryRunUnknownRef))
 	}
 }
 

--- a/chronosphere/set_unknown_test.go
+++ b/chronosphere/set_unknown_test.go
@@ -84,7 +84,7 @@ func TestSetUnknown(t *testing.T) {
 			}),
 			want: &singleTFID{
 				Name:   "michael",
-				RefVal: dummyRef,
+				RefVal: dryRunUnknownRef,
 			},
 		},
 		{
@@ -124,8 +124,8 @@ func TestSetUnknown(t *testing.T) {
 			}),
 			want: &multipleTFID{
 				Name:    "michael",
-				RefVal:  dummyRef,
-				RefVal2: dummyRef,
+				RefVal:  dryRunUnknownRef,
+				RefVal2: dryRunUnknownRef,
 			},
 		},
 		{
@@ -152,7 +152,7 @@ func TestSetUnknown(t *testing.T) {
 			skipIDs: set.New("nested.ref_val"),
 			want: &nestedTFID{
 				Name:   "michael",
-				RefVal: dummyRef,
+				RefVal: dryRunUnknownRef,
 				Nested: singleTFID{
 					Name: "michael",
 				},
@@ -190,7 +190,7 @@ func TestSetUnknown(t *testing.T) {
 			want: &sliceOfRefs{
 				Name:    "michael",
 				RefVals: []tfid.ID{tfid.Slug(""), tfid.Slug("")},
-				RefVal:  dummyRef,
+				RefVal:  dryRunUnknownRef,
 			},
 		},
 		{
@@ -235,7 +235,7 @@ func TestSetUnknown(t *testing.T) {
 				MapRefs: map[string]tfid.ID{
 					"one": tfid.Slug(""),
 				},
-				RefVal: dummyRef,
+				RefVal: dryRunUnknownRef,
 			},
 		},
 		{


### PR DESCRIPTION
When a recording rule has `execution_group` and a `bucket_slug` set,
they're expected to match. However at dry-run time, the `bucket_slug`
may not be known yet and is set to a dummy value which won't match
`execution_group` and fail to validate.

Update validation to use the `execution_group` as the `bucket_slug`
if it's unknown.

As part of this, use a clearer value for unknown dry-run references.