### PR TITLE
Update logging monitor example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Added:
 * Add `priority_thresholds` to `chronosphere_resource_pools_config` pools.
+* Update `monitors-logging` example.
 
 ## v1.7.0
 

--- a/examples/monitors-logging/main.tf
+++ b/examples/monitors-logging/main.tf
@@ -3,7 +3,7 @@ resource "chronosphere_monitor" "monitor_with_logging_query" {
   collection_id = chronosphere_collection.infra.id
   query {
     logging_expr = <<-EOF
-      service = "nginx" | make-series by chronosphere_namespace
+      service = "nginx" | make-series step 1m by chronosphere_namespace
     EOF
   }
   series_conditions {


### PR DESCRIPTION
Logging monitor queries will now require step size. This updates the example to reflect that.

[sc-127595]
cc @chronosphereio/logging 