### PR TITLE
[docs] Update README with current documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Terraform Chronosphere Provider
 
-The Terraform Chronopshere Provider allows [Terraform](https://terraform.io) to manage supported [Chronosphere resources](https://docs.chronosphere.io/administer/infrastructure#supported-resources).
+The Terraform Chronosphere Provider allows [Terraform](https://terraform.io) to manage supported [Chronosphere resources](https://docs.chronosphere.io/tooling/infrastructure#supported-resources).
 
-- [Documentation](https://docs.chronosphere.io/administer/infrastructure/terraform)
+- [Documentation](https://docs.chronosphere.io/tooling/infrastructure/terraform)
 
 ## Contact support
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The Terraform Chronosphere Provider allows [Terraform](https://terraform.io) to 
 
 ## Contact support
 
-[Contact Chronosphere support](https://docs.chronosphere.io/support/contact-support) to ask questions, report bugs, or suggest feature requests.
+[Contact Chronosphere support](https://docs.chronosphere.io/support) to ask questions, report bugs, or suggest feature requests.


### PR DESCRIPTION
We recently moved the Terraform documentation to a new TOOLS section of the docs. This PR updates the `README` to use the updated URLs.