### PR TITLE
Add time window and enable burn rate alerting fields to SLOs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Releases
 
 # Unreleased
+Added:
+* Add enable burn rate alerting field to the unstable `chronosphere_slo` resource.
+* Add time window to the unstable `chronosphere_slo` resource.
 
 Removed:
 * Remove query less SLO fields from unstable `chronosphere_slo` resource.
+* Remove `reporting_windows` from unstable `chronosphere_slo` resource.
 
 ## 1.9.0
 

--- a/chronosphere/intschema/slo.go
+++ b/chronosphere/intschema/slo.go
@@ -76,11 +76,12 @@ type SloSliCustomIndicator struct {
 
 type SloDefinition struct {
 	Objective              float64                               `intschema:"objective"`
-	ReportingWindows       []SloDefinitionReportingWindows       `intschema:"reporting_windows"`
 	BurnRateAlertingConfig []SloDefinitionBurnRateAlertingConfig `intschema:"burn_rate_alerting_config,optional,computed"`
+	EnableBurnRateAlerting bool                                  `intschema:"enable_burn_rate_alerting,optional,computed"`
+	TimeWindow             *SloDefinitionTimeWindow              `intschema:"time_window,optional,computed,list_encoded_object"`
 }
 
-type SloDefinitionReportingWindows struct {
+type SloDefinitionTimeWindow struct {
 	Duration string `intschema:"duration"`
 }
 

--- a/chronosphere/resource_slo.go
+++ b/chronosphere/resource_slo.go
@@ -83,8 +83,9 @@ func (sloConverter) toModel(s *intschema.Slo) (*models.ConfigunstableSLO, error)
 		NotificationPolicySlug: s.NotificationPolicyId.Slug(),
 		Definition: &models.SLODefinition{
 			Objective:              s.Definition.Objective,
-			ReportingWindows:       reportingWindowsToModel(s.Definition.ReportingWindows),
 			BurnRateAlertingConfig: burnRateDefinitionToModel(s.Definition.BurnRateAlertingConfig),
+			TimeWindow:             timeWindowToModel(s.Definition.TimeWindow),
+			EnableBurnRateAlerting: s.Definition.EnableBurnRateAlerting,
 		},
 		Sli: &models.ConfigunstableSLI{
 			CustomIndicator:         customIndicator,
@@ -125,8 +126,9 @@ func (sloConverter) fromModel(
 		Description:          s.Description,
 		Definition: intschema.SloDefinition{
 			Objective:              s.Definition.Objective,
-			ReportingWindows:       reportingWindowsFromModel(s.Definition.ReportingWindows),
+			TimeWindow:             timeWindowFromModel(s.Definition.TimeWindow),
 			BurnRateAlertingConfig: burnRateDefinitionFromModel(s.Definition.BurnRateAlertingConfig),
+			EnableBurnRateAlerting: s.Definition.EnableBurnRateAlerting,
 		},
 		Sli: intschema.SloSli{
 			CustomIndicator:         customIndicator,
@@ -173,16 +175,18 @@ func promFiltersFromModel(filters []*models.ConfigunstablePromQLMatcher) []intsc
 	})
 }
 
-func reportingWindowsToModel(windows []intschema.SloDefinitionReportingWindows) []*models.DefinitionTimeWindow {
-	return sliceutil.Map(windows, func(w intschema.SloDefinitionReportingWindows) *models.DefinitionTimeWindow {
-		return &models.DefinitionTimeWindow{Duration: w.Duration}
-	})
+func timeWindowToModel(window *intschema.SloDefinitionTimeWindow) *models.DefinitionTimeWindow {
+	if window == nil {
+		return nil
+	}
+	return &models.DefinitionTimeWindow{Duration: window.Duration}
 }
 
-func reportingWindowsFromModel(windows []*models.DefinitionTimeWindow) []intschema.SloDefinitionReportingWindows {
-	return sliceutil.Map(windows, func(w *models.DefinitionTimeWindow) intschema.SloDefinitionReportingWindows {
-		return intschema.SloDefinitionReportingWindows{Duration: w.Duration}
-	})
+func timeWindowFromModel(window *models.DefinitionTimeWindow) *intschema.SloDefinitionTimeWindow {
+	if window == nil {
+		return nil
+	}
+	return &intschema.SloDefinitionTimeWindow{Duration: window.Duration}
 }
 
 func burnRateDefinitionToModel(defs []intschema.SloDefinitionBurnRateAlertingConfig) []*models.DefinitionBurnRateDefinition {

--- a/chronosphere/tfschema/slo.go
+++ b/chronosphere/tfschema/slo.go
@@ -87,10 +87,12 @@ var SloDefinition = map[string]*schema.Schema{
 		Type:     schema.TypeFloat,
 		Required: true,
 	},
-	"reporting_windows": {
-		Type:     schema.TypeSet,
-		Required: true,
+	"time_window": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
 		MinItems: 1,
+		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"duration": {
@@ -107,6 +109,11 @@ var SloDefinition = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: BurnRateDefinition,
 		},
+	},
+	"enable_burn_rate_alerting": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Computed: true, // This has to be computed as it's being backfilled based on other flags.
 	},
 }
 

--- a/examples/slo/main.tf
+++ b/examples/slo/main.tf
@@ -30,9 +30,10 @@ resource "chronosphere_slo" "slo" {
 
   definition {
     objective = 99.95
-    reporting_windows {
+    time_window {
       duration = "28d"
     }
+    enable_burn_rate_alerting = true
   }
 
   sli {
@@ -55,7 +56,7 @@ resource "chronosphere_slo" "slo_with_signal_grouping_signal_per_series" {
 
   definition {
     objective = 99.95
-    reporting_windows {
+    time_window {
       duration = "28d"
     }
     burn_rate_alerting_config {
@@ -79,6 +80,7 @@ resource "chronosphere_slo" "slo_with_signal_grouping_signal_per_series" {
       budget = 99
       severity = "warn"
     }
+    enable_burn_rate_alerting = true
   }
 
   sli {
@@ -100,9 +102,10 @@ resource "chronosphere_slo" "slo_with_signal_grouping_labels" {
 
   definition {
     objective = 99.95
-    reporting_windows {
+    time_window {
       duration = "28d"
     }
+    enable_burn_rate_alerting = true
   }
 
   sli {
@@ -120,16 +123,17 @@ resource "chronosphere_slo" "slo_with_filters" {
 
   definition {
     objective = 99.95
-    reporting_windows {
+    time_window {
       duration = "28d"
     }
+    enable_burn_rate_alerting = true
   }
 
   sli {
     custom_indicator {
       bad_query_template   = <<-EOT
         sum(rate(http_request_duration_seconds_count{
-            error=\"true\",
+            error="true",
             {{ .AdditionalFilters }}
         }[{{ .Window }}]))
       EOT
@@ -148,9 +152,30 @@ resource "chronosphere_slo" "slo_with_filters" {
     }
 
     additional_promql_filters{
-        name = "namespace"
-        type = "MatchRegex"
-        value = "foo.*"
+      name = "namespace"
+      type = "MatchRegexp"
+      value = "foo.*"
     }
+  }
+}
+
+resource "chronosphere_slo" "slo_without_alerting" {
+  name                   = "SLO Without Alerting"
+  collection_id          = chronosphere_collection.c.id
+  notification_policy_id = chronosphere_notification_policy.np.id
+
+  definition {
+    objective = 99.95
+    time_window {
+      duration = "28d"
+    }
+  }
+
+  sli {
+    custom_indicator {
+      bad_query_template   = "sum(rate(http_request_duration_seconds_count{error=\"true\"}[{{ .Window }}]))"
+      total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
+    }
+    custom_dimension_labels = ["label1", "label2"]
   }
 }


### PR DESCRIPTION
These will supersede reporting_windows and the is preview flag
which will be deprecated in a future change.

Scenarios [PR](https://github.com/chronosphereio/terraform-provider-chronosphere-scenarios/pull/1089) [Run](https://buildkite.com/chronosphere/terraform-provider-tests/builds/7056#01961bf1-fff0-4433-a97d-696a460e0fc2)