### PR TITLE
Deprecate permissive in rollup rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 Added:
 * Add timeslice indicator support to `chronosphere_slo` resource with `custom_timeslice_indicator` field.
 
+Deprecated:
+* Deprecate `permissive` in `chronosphere_rollup_rule`.
+
 ## v1.10.0
 
 Added:

--- a/chronosphere/tfschema/rollup_rule.go
+++ b/chronosphere/tfschema/rollup_rule.go
@@ -100,9 +100,10 @@ var RollupRule = map[string]*schema.Schema{
 		Default:  false,
 	},
 	"permissive": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
+		Type:       schema.TypeBool,
+		Optional:   true,
+		Default:    false,
+		Deprecated: "permissive is no longer supported",
 	},
 	"mode": Enum{
 		Value:    enum.RollupModeType.ToStrings(),


### PR DESCRIPTION
Marking `permissive` as deprecated to reflect https://github.com/chronosphereio/monorepo/pull/68387.