### PR TITLE
Fix `make install-snapshot` for goreleaser v2.11.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: terraform-provider-chronosphere
 before:
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ TESTPKGS?=$$(go list ./... | grep -v 'vendor' | grep -v 'scenario')
 TOOLS_BIN=$(abspath ./bin)
 OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell uname -m | sed "s/x86_64/amd64/" | sed "s/aarch64/arm64/")
+ARCH_VERSION := $(shell \
+  if [ "$(ARCH)" = "arm64" ]; then go env GOARM64; \
+  elif [ "$(ARCH)" = "amd64" ]; then go env GOAMD64; \
+  else echo ""; fi)
 OS_ARCH=${OS}_${ARCH}
 SHELL=/bin/bash -o pipefail
 
@@ -165,9 +169,9 @@ install-snapshot: snapshot verify-terraform-arch
 	@echo "Installing snapshot version: ${SNAPSHOT_VERSION}-SNAPSHOT-${LATEST_GIT_COMMIT}"
 	@echo "Installing snapshot binary: ${SNAPSHOT_BINARY}"
 	mkdir -p ~/.terraform.d/plugins/${OS_ARCH}
-	cp ./dist/terraform-provider-chronosphere_${OS_ARCH}/${SNAPSHOT_BINARY} ~/.terraform.d/plugins/${OS_ARCH}
+	cp ./dist/terraform-provider-chronosphere_${OS_ARCH}_${ARCH_VERSION}/${SNAPSHOT_BINARY} ~/.terraform.d/plugins/${OS_ARCH}
 	mkdir -p ~/.terraform.d/plugins/local/chronosphereio/chronosphere/${LOCAL_SNAPSHOT_VERSION_DIR}/${OS_ARCH}/
-	cp ./dist/terraform-provider-chronosphere_${OS_ARCH}/${SNAPSHOT_BINARY} ~/.terraform.d/plugins/local/chronosphereio/chronosphere/${LOCAL_SNAPSHOT_VERSION_DIR}/${OS_ARCH}
+	cp ./dist/terraform-provider-chronosphere_${OS_ARCH}_${ARCH_VERSION}/${SNAPSHOT_BINARY} ~/.terraform.d/plugins/local/chronosphereio/chronosphere/${LOCAL_SNAPSHOT_VERSION_DIR}/${OS_ARCH}
 	@echo "Installed snapshot version: ${SNAPSHOT_VERSION}-SNAPSHOT-${LATEST_GIT_COMMIT}"
 	@echo ""
 	@echo "reference this in your terraform code like so:"


### PR DESCRIPTION
When upgrading to goreleaser v2, there were some breaking
changes to the `make install-snapshot` target. The main
one is that goreleaser now includes arch versions (e.g. GOARM64 or GOAMD64)
in the build directory name: https://goreleaser.com/customization/builds/go/#why-is-there-a-_v1-suffix-on-amd64-builds

It doesn't seem there's a way to disable this, so
we have to work it into our Makefile.
