### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
+## v1.12.0
+
 Added:
-* Add unstable `chronosphere_consumption_config` resource.
-* Add unstable `chronosphere_consumption_budget` resource.
-* Update parser support in LogIngestConfig.
+* Add unstable `chronosphere_consumption_config` resource for configuring telemetry data partitions.
+* Add unstable `chronosphere_consumption_budget` resource for configuring telemetry data partitions.
+* Update parsing support in `chronosphere_log_ingest_config` resource.
 
 Deprecated:
-* Deprecate `permissive` in `chronosphere_rollup_rule`.
+* Deprecate `permissive` in `chronosphere_rollup_rule` resource.
 
 ## v1.11.0
 


### PR DESCRIPTION
- 9886cd8 Fix misplaced CHANGELOG entry
- 05456c7 Fix `make install-snapshot` for goreleaser v2.11.1
- 8300e38 implement new ConsumptionBudget fields
- cf48c62 make update-swagger
- 740c145 Update log parsers API
- 4753528 unstable chronosphere_consumption_budget resource
- 62852e8 unstable chronosphere_consumption_config resource
- 79a29f2 make update-swagger
- 70499b3 Upgrade to go 1.24.5
- cba5ae8 Deprecate permissive in rollup rules
