### PR TITLE
Revert "Update drop rules to support mode instead of active (#154)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@
 * Add `azure_metrics_integration` resource for configuring the cloudscraper Azure metrics integration.
 
 
-Added:
-* Add `mode` field to `chronosphere_drop_rule` resource with values `enabled`, `disabled`, and `preview`.
-
-Deprecated:
-* Deprecate `active` field in `chronosphere_drop_rule` resource in favor of `mode` field.
-
 ## v1.13.0
 
 Added:

--- a/chronosphere/enum/mode_type.go
+++ b/chronosphere/enum/mode_type.go
@@ -41,19 +41,3 @@ var MappingModeType = newEnum("MappingModeType", []value[configv1.Configv1Mappin
 		alias: "PREVIEW",
 	},
 })
-
-// DropRuleModeType is an enum.
-var DropRuleModeType = newEnum("DropRuleModeType", []value[configv1.Configv1DropRuleMode]{
-	{
-		v1:        configv1.Configv1DropRuleModeENABLED,
-		isDefault: true,
-	},
-	{
-		v1:    configv1.Configv1DropRuleModeDISABLED,
-		alias: "DISABLED",
-	},
-	{
-		v1:    configv1.Configv1DropRuleModePREVIEW,
-		alias: "PREVIEW",
-	},
-})

--- a/chronosphere/intschema/drop_rule.go
+++ b/chronosphere/intschema/drop_rule.go
@@ -21,7 +21,6 @@ type DropRule struct {
 	Active                bool                    `intschema:"active,optional,default:false"`
 	ConditionalDrop       bool                    `intschema:"conditional_drop,optional"`
 	DropNanValue          bool                    `intschema:"drop_nan_value,optional"`
-	Mode                  string                  `intschema:"mode,optional"`
 	RateLimitThreshold    float64                 `intschema:"rate_limit_threshold,optional"`
 	ValueBasedDrop        *DropRuleValueBasedDrop `intschema:"value_based_drop,optional,list_encoded_object"`
 

--- a/chronosphere/resource_drop_rule.go
+++ b/chronosphere/resource_drop_rule.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/aggregationfilter"
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/enum"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/intschema"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
@@ -66,19 +65,10 @@ func (dropRuleConverter) toModel(
 	if err != nil {
 		return nil, err
 	}
-
-	// Use Mode field if set, otherwise fall back to Active field
-	var mode models.Configv1DropRuleMode
-	if r.Mode != "" {
-		mode = enum.DropRuleModeType.V1(r.Mode)
-	} else {
-		mode = dropRuleModeToModel(r.Active)
-	}
-
 	return &models.Configv1DropRule{
 		Name:                     r.Name,
 		Slug:                     r.Slug,
-		Mode:                     mode,
+		Mode:                     dropRuleModeToModel(r.Active),
 		Filters:                  filter,
 		ConditionalRateBasedDrop: conditionalRateBasedDrop,
 		DropNanValue:             r.DropNanValue,
@@ -92,7 +82,6 @@ func (dropRuleConverter) fromModel(
 	r := &intschema.DropRule{
 		Name:           m.Name,
 		Slug:           m.Slug,
-		Mode:           string(m.Mode),
 		Active:         m.Mode == models.Configv1DropRuleModeENABLED,
 		Query:          aggregationfilter.ListFromModel(m.Filters, aggregationfilter.DropRuleDelimiter),
 		DropNanValue:   m.DropNanValue,

--- a/chronosphere/tfschema/drop_rule.go
+++ b/chronosphere/tfschema/drop_rule.go
@@ -16,8 +16,6 @@ package tfschema
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/enum"
 )
 
 var DropRule = map[string]*schema.Schema{
@@ -28,15 +26,10 @@ var DropRule = map[string]*schema.Schema{
 		ForceNew: true,
 	},
 	"active": {
-		Type:       schema.TypeBool,
-		Optional:   true,
-		Default:    false,
-		Deprecated: "use `mode` instead",
-	},
-	"mode": Enum{
-		Value:    enum.DropRuleModeType.ToStrings(),
+		Type:     schema.TypeBool,
 		Optional: true,
-	}.Schema(),
+		Default:  false,
+	},
 	"name": {
 		Type:     schema.TypeString,
 		Required: true,


### PR DESCRIPTION
This reverts commit da6ac31c192f36dba4c999f6ee94a39e717619e2.

Need to redo this because it's backwards incompatible given how server-side we always set `mode` field, whether the caller specified `active` OR `mode`.

See https://chronosphereio.slack.com/archives/C02J28DB9E3/p1759261803111469?thread_ts=1759245879.680839&cid=C02J28DB9E3