### PR TITLE
Release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.14.0
+
 Added:
 * Add `azure_metrics_integration` resource for configuring the cloudscraper Azure metrics integration.
 * Add `mode` field to `chronosphere_drop_rule` resource with values `enabled`, `disabled`, and `preview`. The default value of `mode` is `ENABLED` which is a breaking change given that the now-deprecated `active` field's default value was originally `false` (i.e. `DISABLED`).


### PR DESCRIPTION
- 9d1e416 Update chronosphere_drop_rule to include mode field and deprecate active field 
- faabf0d Revert "Update drop rules to support mode instead of active " 
- b964475 Add resource definition for Azure Metrics Integration 
- da6ac31 Update drop rules to support mode instead of active 
- 6129ffa Run make update-swagger