### PR TITLE
Update schema for log control and ingest configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Releases
 
 ## UNRELEASED
-* Update swagger to be consistent with latest API changes.
+Added:
+* Add `parse_field` control rule type and `grok_parser` support to `chronosphere_log_control_config` and `chronosphere_log_ingest_config` resources.
 
 ## v1.24.0
 

--- a/chronosphere/enum/enum_test.go
+++ b/chronosphere/enum/enum_test.go
@@ -175,6 +175,10 @@ func TestAllEnumsValidate(t *testing.T) {
 			v1SwaggerName: "configv1LogRetentionConfigMode",
 			enum:          LogRetentionConfigMode.ToStrings(),
 		},
+		{
+			v1SwaggerName: "LogParserParserType",
+			enum:          LogParserType.ToStrings(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.enum.Name(), func(t *testing.T) {

--- a/chronosphere/enum/log_control_rule_type.go
+++ b/chronosphere/enum/log_control_rule_type.go
@@ -40,4 +40,8 @@ var LogControlRuleType = newEnum("LogControlRuleType", []value[configv1.Configv1
 		v1:    configv1.Configv1LogControlRuleTypeEMITMETRICS,
 		alias: "EMIT_METRICS",
 	},
+	{
+		v1:    configv1.Configv1LogControlRuleTypePARSEFIELD,
+		alias: "PARSE_FIELD",
+	},
 })

--- a/chronosphere/enum/log_parser.go
+++ b/chronosphere/enum/log_parser.go
@@ -56,4 +56,8 @@ var LogParserType = newEnum("LogParserType", []value[configv1.LogParserParserTyp
 		v1:    configv1.LogParserParserTypeKEYVALUE,
 		alias: "KEY_VALUE",
 	},
+	{
+		v1:    configv1.LogParserParserTypeGROK,
+		alias: "GROK",
+	},
 })

--- a/chronosphere/intschema/log_control_config.go
+++ b/chronosphere/intschema/log_control_config.go
@@ -59,6 +59,7 @@ type LogControlConfigRules struct {
 	EmitMetrics  *LogControlConfigRulesEmitMetrics  `intschema:"emit_metrics,optional,list_encoded_object"`
 	Filter       string                             `intschema:"filter,optional"`
 	Mode         string                             `intschema:"mode,optional"`
+	ParseField   *LogControlConfigRulesParseField   `intschema:"parse_field,optional,list_encoded_object"`
 	ReplaceField *LogControlConfigRulesReplaceField `intschema:"replace_field,optional,list_encoded_object"`
 	Sample       *LogControlConfigRulesSample       `intschema:"sample,optional,list_encoded_object"`
 	Type         string                             `intschema:"type,optional"`
@@ -90,6 +91,12 @@ type LogControlConfigRulesReplaceFieldMappedValue struct {
 type LogControlConfigRulesReplaceFieldMappedValuePairs struct {
 	Key   string `intschema:"key,optional"`
 	Value string `intschema:"value,optional"`
+}
+
+type LogControlConfigRulesParseField struct {
+	Destination *LogControlConfigFieldPath `intschema:"destination,optional,list_encoded_object"`
+	Parser      *LogParser                 `intschema:"parser,optional,list_encoded_object"`
+	Source      *LogControlConfigFieldPath `intschema:"source,optional,list_encoded_object"`
 }
 
 type LogControlConfigRulesEmitMetrics struct {

--- a/chronosphere/intschema/shared_schemas.go
+++ b/chronosphere/intschema/shared_schemas.go
@@ -38,9 +38,14 @@ type LogIngestConfigStringNormalization struct {
 }
 
 type LogParser struct {
-	ParserType     string          `intschema:"parser_type"`
-	KeyValueParser *KeyValueParser `intschema:"key_value_parser,optional,list_encoded_object"`
-	RegexParser    *RegexParser    `intschema:"regex_parser,optional,list_encoded_object"`
+	ParserType     string               `intschema:"parser_type"`
+	GrokParser     *LogParserGrokParser `intschema:"grok_parser,optional,list_encoded_object"`
+	KeyValueParser *KeyValueParser      `intschema:"key_value_parser,optional,list_encoded_object"`
+	RegexParser    *RegexParser         `intschema:"regex_parser,optional,list_encoded_object"`
+}
+
+type LogParserGrokParser struct {
+	Pattern string `intschema:"pattern"`
 }
 
 type LogPrioritiesSchema struct {

--- a/chronosphere/resource_log_control_config.go
+++ b/chronosphere/resource_log_control_config.go
@@ -91,6 +91,7 @@ func (logControlConfigConverter) toModel(
 			}
 			rule.EmitMetrics = convertEmitMetricsToModel(r.EmitMetrics)
 			rule.ReplaceField = convertReplaceFieldToModel(r.ReplaceField)
+			rule.ParseField = convertParseFieldToModel(r.ParseField)
 
 			return rule
 		}),
@@ -133,6 +134,7 @@ func (logControlConfigConverter) fromModel(
 
 			rule.EmitMetrics = convertEmitMetricsFromModel(r.EmitMetrics)
 			rule.ReplaceField = convertReplaceFieldFromModel(r.ReplaceField)
+			rule.ParseField = convertParseFieldFromModel(r.ParseField)
 
 			return rule
 		}),
@@ -322,6 +324,54 @@ func convertReplaceFieldFromModel(rf *models.LogControlRuleReplaceField) *intsch
 	if rf.StaticValue != nil {
 		result.StaticValue = &intschema.LogControlConfigRulesReplaceFieldStaticValue{
 			Value: rf.StaticValue.Value,
+		}
+	}
+
+	return result
+}
+
+func convertParseFieldToModel(pf *intschema.LogControlConfigRulesParseField) *models.LogControlRuleParseField {
+	if pf == nil {
+		return nil
+	}
+
+	result := &models.LogControlRuleParseField{
+		Parser: convertLogParserToModel(pf.Parser),
+	}
+
+	if pf.Source != nil {
+		result.Source = &models.Configv1LogFieldPath{
+			Selector: pf.Source.Selector,
+		}
+	}
+
+	if pf.Destination != nil {
+		result.Destination = &models.Configv1LogFieldPath{
+			Selector: pf.Destination.Selector,
+		}
+	}
+
+	return result
+}
+
+func convertParseFieldFromModel(pf *models.LogControlRuleParseField) *intschema.LogControlConfigRulesParseField {
+	if pf == nil {
+		return nil
+	}
+
+	result := &intschema.LogControlConfigRulesParseField{
+		Parser: convertLogParserFromModel(pf.Parser),
+	}
+
+	if pf.Source != nil {
+		result.Source = &intschema.LogControlConfigFieldPath{
+			Selector: pf.Source.Selector,
+		}
+	}
+
+	if pf.Destination != nil {
+		result.Destination = &intschema.LogControlConfigFieldPath{
+			Selector: pf.Destination.Selector,
 		}
 	}
 

--- a/chronosphere/resource_log_ingest_config.go
+++ b/chronosphere/resource_log_ingest_config.go
@@ -112,6 +112,12 @@ func convertLogParserToModel(p *intschema.LogParser) *models.LogIngestConfigLogP
 		}
 	}
 
+	if p.GrokParser != nil {
+		result.GrokParser = &models.LogParserGrokParser{
+			Pattern: p.GrokParser.Pattern,
+		}
+	}
+
 	return result
 }
 
@@ -152,6 +158,9 @@ func (logIngestConfigConverter) fromModel(
 }
 
 func convertLogParserFromModel(p *models.LogIngestConfigLogParser) *intschema.LogParser {
+	if p == nil {
+		return nil
+	}
 	result := &intschema.LogParser{
 		ParserType: string(p.ParserType),
 	}
@@ -167,6 +176,12 @@ func convertLogParserFromModel(p *models.LogIngestConfigLogParser) *intschema.Lo
 			PairSeparator: p.KeyValueParser.PairSeparator,
 			Delimiter:     p.KeyValueParser.Delimiter,
 			TrimSet:       p.KeyValueParser.TrimSet,
+		}
+	}
+
+	if p.GrokParser != nil {
+		result.GrokParser = &intschema.LogParserGrokParser{
+			Pattern: p.GrokParser.Pattern,
 		}
 	}
 

--- a/chronosphere/tfschema/log_control_config.go
+++ b/chronosphere/tfschema/log_control_config.go
@@ -70,6 +70,12 @@ var logControlRuleResource = &schema.Resource{
 			Optional: true,
 			MaxItems: 1,
 		},
+		"parse_field": {
+			Type:     schema.TypeList,
+			Elem:     logControlRuleParseFieldResource,
+			Optional: true,
+			MaxItems: 1,
+		},
 	},
 }
 
@@ -245,5 +251,13 @@ var logControlRuleReplaceFieldStaticValueResource = &schema.Resource{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+	},
+}
+
+var logControlRuleParseFieldResource = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"source":      LogFieldPathSchema,
+		"destination": LogFieldPathSchema,
+		"parser":      LogParserSchema,
 	},
 }

--- a/chronosphere/tfschema/log_ingest_config.go
+++ b/chronosphere/tfschema/log_ingest_config.go
@@ -84,6 +84,7 @@ var LogParserSchema = &schema.Schema{
 			}.Schema(),
 			"regex_parser":     RegexLogParserSchema,
 			"key_value_parser": KeyValueLogParserSchema,
+			"grok_parser":      GrokLogParserSchema,
 		},
 	},
 	Required: true,
@@ -119,6 +120,20 @@ var KeyValueLogParserSchema = &schema.Schema{
 			"trim_set": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+		},
+	},
+	Optional: true,
+	MaxItems: 1,
+}
+
+var GrokLogParserSchema = &schema.Schema{
+	Type: schema.TypeList,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"pattern": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 		},
 	},


### PR DESCRIPTION
Updates the log ingest and control resources with new parser and control rule type.
Scenario tests are passing with build # 7231.