### PR TITLE
Skip unknown destination external_connection_slug refs during dry-run

### DIFF
--- a/chronosphere/resource_notification_policy.go
+++ b/chronosphere/resource_notification_policy.go
@@ -251,6 +251,16 @@ func (npr *notificationPolicyResourceMeta) resourceNotificationPolicyCustomizeDi
 		SetUnknownReferencesSkip: []string{
 			"route.[].notifiers.[]",
 			"override.[].route.[].notifiers.[]",
+			"route.[].destination.[].slack.[].external_connection_slug",
+			"route.[].destination.[].pagerduty.[].external_connection_slug",
+			"route.[].destination.[].webhook.[].external_connection_slug",
+			"route.[].destination.[].ops_genie.[].external_connection_slug",
+			"route.[].destination.[].victor_ops.[].external_connection_slug",
+			"override.[].route.[].destination.[].slack.[].external_connection_slug",
+			"override.[].route.[].destination.[].pagerduty.[].external_connection_slug",
+			"override.[].route.[].destination.[].webhook.[].external_connection_slug",
+			"override.[].route.[].destination.[].ops_genie.[].external_connection_slug",
+			"override.[].route.[].destination.[].victor_ops.[].external_connection_slug",
 		},
 
 		ModifyAPIModel: func(apiPolicy *configmodels.Configv1NotificationPolicy) {


### PR DESCRIPTION
[The scenarios PR](https://github.com/chronosphereio/terraform-provider-chronosphere-scenarios/pull/1165) associated with [this provider change](https://github.com/chronosphereio/terraform-provider-chronosphere/pull/200) is failing CI. This PR should fix those issues