### PR TITLE
Release v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## v1.28.0
+
 Added:
 * Add `ROLLING_30_MINUTE_VOLUME` threshold type to `chronosphere_consumption_budget` thresholds.
 


### PR DESCRIPTION
Promote queued entries to v1.28.0.

## Commits since v1.27.0

- 155eb00 Preserve configured secrets when alert notifier reads are redacted (#209)
- 49bcba9 Add ROLLING_30_MINUTE_VOLUME consumption budget threshold (#208)
- 8f64de3 Move example scenarios to examples/scenarios/ (#211) — internal repo reorg, no CHANGELOG entry

## Note

Do not merge until the documentation repo release-notes PR is also approved.