### PR TITLE
Upgrade Go to 1.26.1 [ignore-release]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24.5"
+          go-version: "1.26.1"
 
       - name: Build
         run: make build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.24.5"
+        go-version: "1.26.1"
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/chronosphereio/terraform-provider-chronosphere
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1 => github.com/chronosphereio/terraform-plugin-sdk/v2 v2.0.0-20220830001851-edb6d12500f2
 
-go 1.24.5
+go 1.26.1
 
 require (
 	github.com/getkin/kin-openapi v0.98.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronosphereio/terraform-provider-chronosphere/tools
 
-go 1.24.5
+go 1.26.1
 
 require (
 	github.com/go-swagger/go-swagger v0.30.4


### PR DESCRIPTION
## What
Bump Go from 1.24.5 to **1.26.1** — `go.mod`, `tools/go.mod`, and the CI `setup-go` version.

## Why
Prerequisite for the `terraform-plugin-sdk` fork upgrade (requires go >= 1.25.8). Pinned to **1.26.1** (not 1.26.4) so it stays within what the scenarios goreleaser image (`goreleaser-gpg-agent:v2.16.0` = Go 1.26.3) can build under `GOTOOLCHAIN=local`.

## Coordination
Per the dual-PR flow, this OSS PR lands first; the private scenarios PR (#1175) pins this commit for integration testing and merges after this releases.