### PR TITLE
Release v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## UNRELEASED
 
+## v1.29.0
+
 Added:
 * Add `resource_group` field to `chronosphere_consumption_budget` thresholds as
   a replacement for the deprecated `sku_group` field. Both accept the same
   values; `resource_group` is preferred.
+* Add field-level descriptions across all resource and data-source schemas, and
+  publish generated reference documentation to the Terraform Registry via a new
+  `make docs` target that runs `tfplugindocs`. Schema helpers (`Duration`,
+  `Enum`, `CaseInsensitiveString`, `Filter`, `typeset.Set`) now accept a
+  `Description`. (The implementing code merged after the v1.28.0 tag, so the
+  generated registry documentation is first published with this release.)
 
 Deprecated:
 * Deprecate the `sku_group` field on `chronosphere_consumption_budget`
@@ -15,7 +23,7 @@ Deprecated:
 
 Added:
 * Add `ROLLING_30_MINUTE_VOLUME` threshold type to `chronosphere_consumption_budget` thresholds.
-* Add field-level descriptions across all resource and data-source schemas, and add a `make docs` target that runs `tfplugindocs` to generate `docs/` for the Terraform Registry. Schema helpers (`Duration`, `Enum`, `CaseInsensitiveString`, `Filter`, `typeset.Set`) now accept a `Description`.
+* Add field-level descriptions across all resource and data-source schemas, and add a `make docs` target that runs `tfplugindocs` to generate `docs/` for the Terraform Registry. Schema helpers (`Duration`, `Enum`, `CaseInsensitiveString`, `Filter`, `typeset.Set`) now accept a `Description`. _(Note: the implementing code merged after the v1.28.0 tag and is first released in v1.29.0.)_
 
 Bug fixes:
 * Preserve configured secret values during refresh of `chronosphere_webhook_alert_notifier`, `chronosphere_slack_alert_notifier`, `chronosphere_pagerduty_alert_notifier`, `chronosphere_opsgenie_alert_notifier`, and `chronosphere_victorops_alert_notifier` when the Config API returns the redaction sentinel for secret fields. Real server-side changes still surface as drift.


### PR DESCRIPTION
Release v1.29.0 of the Terraform provider. Cuts a release of the changes already on `main` since v1.28.0 (no swagger sync / field implementation in this PR).

## Changelog

### Added
* Add `resource_group` field to `chronosphere_consumption_budget` thresholds as a replacement for the deprecated `sku_group` field. Both accept the same values; `resource_group` is preferred.
* Add field-level descriptions across all resource and data-source schemas, and publish generated reference documentation to the Terraform Registry via a new `make docs` target that runs `tfplugindocs`. Schema helpers (`Duration`, `Enum`, `CaseInsensitiveString`, `Filter`, `typeset.Set`) now accept a `Description`. _(The implementing code merged after the v1.28.0 tag, so the generated registry documentation is first published with this release.)_

### Deprecated
* Deprecate the `sku_group` field on `chronosphere_consumption_budget` thresholds. Use `resource_group` instead.

## Commits since v1.28.0
- Add resource_group alias to consumption budget thresholds (#214)
- Add schema descriptions and generate registry docs (#210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)