### PR TITLE
Release v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## v1.30.0
+
 Added:
 * Add `PARENT_SERVICE`, `PARENT_OPERATION`, `ROOT_SERVICE`, and
   `ROOT_OPERATION` group-by key types to `chronosphere_trace_metrics_rule`.


### PR DESCRIPTION
- 6b9ad10 Add parent/root group-by key types to trace metrics rules 
- 24cdedd Remove deprecated sku_group field from consumption budget thresholds 
- 5c6f639 Upgrade terraform-plugin-sdk fork to v2.40.1 [ignore-release] 
- 0be6a73 Upgrade Go to 1.26.1 [ignore-release] 