### PR TITLE
Ignore local Claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ tmp/
 
 # test output from CI targets
 test.log
+
+# Claude
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+CLAUDE.local.md


### PR DESCRIPTION
Local Claude editor/session files (settings, scheduled-task
lock, worktrees, and `CLAUDE.local.md`) currently show up as
untracked noise in `git status`.

Adds a `# Claude` section to `.gitignore` covering these
local files, matching the convention used in our other
repos.