### PR TITLE
Add `ALL` value to `chronosphere_consumption_budget` resource_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Added:
 * Add the `TRACE_PROCESSED_BYTES`, `TRACE_PERSISTED_BYTES`, and `TRACE_ALL`
   values to the `resource_group` field on `chronosphere_consumption_budget`
   thresholds.
+* Add the `ALL` value to the `resource_group` field on
+  `chronosphere_consumption_budget` thresholds.
 
 ## v1.31.0
 

--- a/chronosphere/enum/consumption_budget.go
+++ b/chronosphere/enum/consumption_budget.go
@@ -120,6 +120,10 @@ var ConsumptionBudgetResourceGroup = newEnum("ConsumptionBudgetResourceGroup", [
 		v1:    configv1.ConsumptionBudgetResourceGroupTRACEALL,
 		alias: "TRACE_ALL",
 	},
+	{
+		v1:    configv1.ConsumptionBudgetResourceGroupALL,
+		alias: "ALL",
+	},
 })
 
 // ConsumptionBudgetUnit is an enum.

--- a/chronosphere/pkg/configv1/models/consumption_budget_resource_group.go
+++ b/chronosphere/pkg/configv1/models/consumption_budget_resource_group.go
@@ -53,6 +53,9 @@ const (
 
 	// ConsumptionBudgetResourceGroupTRACEALL captures enum value "TRACE_ALL"
 	ConsumptionBudgetResourceGroupTRACEALL ConsumptionBudgetResourceGroup = "TRACE_ALL"
+
+	// ConsumptionBudgetResourceGroupALL captures enum value "ALL"
+	ConsumptionBudgetResourceGroupALL ConsumptionBudgetResourceGroup = "ALL"
 )
 
 // for schema
@@ -60,7 +63,7 @@ var consumptionBudgetResourceGroupEnum []interface{}
 
 func init() {
 	var res []ConsumptionBudgetResourceGroup
-	if err := json.Unmarshal([]byte(`["LOG_PERSISTED_BYTES","LOG_PROCESSED_BYTES","METRIC_PERSISTED_SERIES","METRIC_ALL","LOG_ALL","TRACE_PROCESSED_BYTES","TRACE_PERSISTED_BYTES","TRACE_ALL"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["LOG_PERSISTED_BYTES","LOG_PROCESSED_BYTES","METRIC_PERSISTED_SERIES","METRIC_ALL","LOG_ALL","TRACE_PROCESSED_BYTES","TRACE_PERSISTED_BYTES","TRACE_ALL","ALL"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/chronosphere/pkg/configv1/swagger.json
+++ b/chronosphere/pkg/configv1/swagger.json
@@ -652,7 +652,8 @@
         "LOG_ALL",
         "TRACE_PROCESSED_BYTES",
         "TRACE_PERSISTED_BYTES",
-        "TRACE_ALL"
+        "TRACE_ALL",
+        "ALL"
       ],
       "type": "string"
     },
@@ -9042,7 +9043,8 @@
                 "LOG_ALL",
                 "TRACE_PROCESSED_BYTES",
                 "TRACE_PERSISTED_BYTES",
-                "TRACE_ALL"
+                "TRACE_ALL",
+                "ALL"
               ],
               "type": "string"
             },


### PR DESCRIPTION
Adds the `ALL` value to the `resource_group` field on
`chronosphere_consumption_budget` thresholds.

The first commit syncs the generated swagger clients; the second
wires the new enum value into the resource schema and adds a
CHANGELOG entry.