### PR TITLE
Add new_series_delay to chronosphere_monitor series conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Added:
 * Add the `resolve_sustain_for_no_data` block to `chronosphere_monitor`
   series conditions, controlling how a firing condition resolves once its
   series stops returning data.
+* Add the `new_series_delay` field to `chronosphere_monitor` series
+  conditions, suppressing a newly observed series until the delay has
+  elapsed since it was first seen.
 
 ## v1.33.0
 

--- a/chronosphere/intschema/shared_schemas.go
+++ b/chronosphere/intschema/shared_schemas.go
@@ -66,6 +66,7 @@ type Matcher struct {
 type MonitorSeriesCondition struct {
 	Op                      string                                         `intschema:"op"`
 	Severity                string                                         `intschema:"severity"`
+	NewSeriesDelay          string                                         `intschema:"new_series_delay,optional"`
 	ResolveSustain          string                                         `intschema:"resolve_sustain,optional"`
 	ResolveSustainForNoData *MonitorSeriesConditionResolveSustainForNoData `intschema:"resolve_sustain_for_no_data,optional,list_encoded_object"`
 	ResolveValue            *MonitorSeriesConditionResolveValue            `intschema:"resolve_value,optional,list_encoded_object"`

--- a/chronosphere/pkg/configv1/models/configv1_monitor_condition.go
+++ b/chronosphere/pkg/configv1/models/configv1_monitor_condition.go
@@ -18,6 +18,27 @@ import (
 // swagger:model configv1MonitorCondition
 type Configv1MonitorCondition struct {
 
+	// How long a newly observed series is suppressed before it can trigger an
+	// alert. A series counts as new until `new_series_delay_secs` has elapsed
+	// since it was first seen. It need not be present continuously over that
+	// period, but it must return at least one datapoint every 24 hours to stay
+	// tracked: a series that goes missing for longer than 24 hours is forgotten
+	// and counts as new again when it comes back. Existence is tracked by
+	// observing the series whether or not it violates the condition.
+	//
+	// This is additive with `sustain_secs`: the sustain clock only starts once
+	// the delay has elapsed. A delay of `3600` combined with a sustain of `300`
+	// means a new violating series becomes pending after 60 minutes and fires
+	// after 65 minutes. A newly created monitor therefore does not alert for up
+	// to `new_series_delay_secs`.
+	//
+	// `0`, the default, disables the delay. Must be at least `0` and at most 1
+	// week (604800 seconds).
+	//
+	// Not supported for `EXISTS`, `NOT_EXISTS`, or `SIGNAL_NOT_EXISTS`
+	// conditions, or for Graphite monitors.
+	NewSeriesDelaySecs int32 `json:"new_series_delay_secs,omitempty"`
+
 	// op
 	Op ConditionOp `json:"op,omitempty"`
 

--- a/chronosphere/pkg/configv1/swagger.json
+++ b/chronosphere/pkg/configv1/swagger.json
@@ -5830,6 +5830,11 @@
         },
         "resolve_sustain_for_no_data": {
           "$ref": "#/definitions/configv1ResolveSustainForNoData"
+        },
+        "new_series_delay_secs": {
+          "description": "How long a newly observed series is suppressed before it can trigger an\nalert. A series counts as new until `new_series_delay_secs` has elapsed\nsince it was first seen. It need not be present continuously over that\nperiod, but it must return at least one datapoint every 24 hours to stay\ntracked: a series that goes missing for longer than 24 hours is forgotten\nand counts as new again when it comes back. Existence is tracked by\nobserving the series whether or not it violates the condition.\n\nThis is additive with `sustain_secs`: the sustain clock only starts once\nthe delay has elapsed. A delay of `3600` combined with a sustain of `300`\nmeans a new violating series becomes pending after 60 minutes and fires\nafter 65 minutes. A newly created monitor therefore does not alert for up\nto `new_series_delay_secs`.\n\n`0`, the default, disables the delay. Must be at least `0` and at most 1\nweek (604800 seconds).\n\nNot supported for `EXISTS`, `NOT_EXISTS`, or `SIGNAL_NOT_EXISTS`\nconditions, or for Graphite monitors.",
+          "format": "int32",
+          "type": "integer"
         }
       },
       "type": "object"

--- a/chronosphere/resource_monitor.go
+++ b/chronosphere/resource_monitor.go
@@ -368,10 +368,15 @@ func monitorConditionsToModel(
 		if err != nil {
 			return nil, err
 		}
+		newSeriesDelaySecs, err := durationToSecs(c.NewSeriesDelay)
+		if err != nil {
+			return nil, err
+		}
 		cond := &models.Configv1MonitorCondition{
 			Op:                 enum.ConditionOp.V1(c.Op),
 			SustainSecs:        sustainSecs,
 			ResolveSustainSecs: resolveSustainSecs,
+			NewSeriesDelaySecs: newSeriesDelaySecs,
 			Value:              c.Value,
 		}
 		if c.ResolveValue != nil {
@@ -427,6 +432,7 @@ func monitorConditionsFromModel(
 				Op:             string(c.Op),
 				Sustain:        durationFromSecs(c.SustainSecs),
 				ResolveSustain: durationFromSecs(c.ResolveSustainSecs),
+				NewSeriesDelay: durationFromSecs(c.NewSeriesDelaySecs),
 				Value:          c.Value,
 			}
 			if c.ResolveValue != nil {

--- a/chronosphere/tfschema/monitor.go
+++ b/chronosphere/tfschema/monitor.go
@@ -233,6 +233,10 @@ var MonitorSeriesConditionSchema = typeset.Set{
 			},
 		}),
 		"resolve_sustain_for_no_data": resolveSustainForNoData{},
+		"new_series_delay": Duration{
+			Optional:    true,
+			Description: "How long a newly observed series is suppressed before it can trigger a signal. A series counts as new until this duration has elapsed since it was first seen; it need not report continuously, but a series absent for more than 24 hours is forgotten and counts as new again when it returns. Additive with `sustain`, which only starts counting once the delay has elapsed. Omitted (or `0`) disables the delay. Must be at most 1 week. Only supported for Prometheus monitors, and not for the `exists`, `not_exists`, or `signal_not_exists` operators.",
+		},
 	},
 }.Schema()
 

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -100,6 +100,7 @@ Required:
 
 Optional:
 
+- `new_series_delay` (String) How long a newly observed series is suppressed before it can trigger a signal. A series counts as new until this duration has elapsed since it was first seen; it need not report continuously, but a series absent for more than 24 hours is forgotten and counts as new again when it returns. Additive with `sustain`, which only starts counting once the delay has elapsed. Omitted (or `0`) disables the delay. Must be at most 1 week. Only supported for Prometheus monitors, and not for the `exists`, `not_exists`, or `signal_not_exists` operators.
 - `resolve_sustain` (String) Duration the condition must remain false continuously before an active signal resolves.
 - `resolve_sustain_for_no_data` (Block List, Max: 1) Controls how a firing condition resolves once its series stops returning data. When this block is omitted (or `enabled` is false), missing data is treated exactly like passing data: `resolve_sustain` governs recovery for both. When enabled, resolution on missing data is governed independently of `resolve_sustain` by `value`. (see [below for nested schema](#nestedblock--series_conditions--condition--resolve_sustain_for_no_data))
 - `resolve_value` (Block List, Max: 1) Optional separate threshold used for resolution, enabling hysteresis (e.g. fire at >90, resolve at <80). (see [below for nested schema](#nestedblock--series_conditions--condition--resolve_value))
@@ -146,6 +147,7 @@ Required:
 
 Optional:
 
+- `new_series_delay` (String) How long a newly observed series is suppressed before it can trigger a signal. A series counts as new until this duration has elapsed since it was first seen; it need not report continuously, but a series absent for more than 24 hours is forgotten and counts as new again when it returns. Additive with `sustain`, which only starts counting once the delay has elapsed. Omitted (or `0`) disables the delay. Must be at most 1 week. Only supported for Prometheus monitors, and not for the `exists`, `not_exists`, or `signal_not_exists` operators.
 - `resolve_sustain` (String) Duration the condition must remain false continuously before an active signal resolves.
 - `resolve_sustain_for_no_data` (Block List, Max: 1) Controls how a firing condition resolves once its series stops returning data. When this block is omitted (or `enabled` is false), missing data is treated exactly like passing data: `resolve_sustain` governs recovery for both. When enabled, resolution on missing data is governed independently of `resolve_sustain` by `value`. (see [below for nested schema](#nestedblock--series_conditions--override--condition--resolve_sustain_for_no_data))
 - `resolve_value` (Block List, Max: 1) Optional separate threshold used for resolution, enabling hysteresis (e.g. fire at >90, resolve at <80). (see [below for nested schema](#nestedblock--series_conditions--override--condition--resolve_value))


### PR DESCRIPTION
## Summary

Adds a `new_series_delay` field to `chronosphere_monitor` series conditions.
The field suppresses a newly observed series until the delay has elapsed
since the series was first seen, so a newly created monitor does not
immediately alert on series it has no history for.

The delay is additive with `sustain`: the sustain clock only starts once the
delay has elapsed. Omitting the field, or setting it to `0`, disables the
delay. The maximum is 1 week.

Exposed as a duration string, consistent with the sibling `sustain` and
`resolve_sustain` fields, and converted to the seconds representation used
by the Config v1 API.

## Changes

- Sync the generated Config v1 API client.
- Add `new_series_delay` to the monitor series condition schema, with
  mapping in both directions in `resource_monitor.go`.
- Regenerate the internal schema and resource docs.
- Add a CHANGELOG entry.