### PR TITLE
Re-enable export and import for chronosphere_synthetic_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ Added:
   so require Terraform 1.11 or later. This resource is backed by the stable
   v1 config API.
 
-Fixed:
-* Include `chronosphere_synthetic_test` in export-config and import-state,
-  which previously skipped synthetic tests while gateways serving the v1
-  synthetic-test API were still rolling out.
-
 Removed:
 * Remove the `chronosphere_logscale_alert` and `chronosphere_logscale_action`
   resources. The endpoints backing them no longer exist in the public API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Added:
   so require Terraform 1.11 or later. This resource is backed by the stable
   v1 config API.
 
+Fixed:
+* Include `chronosphere_synthetic_test` in export-config and import-state,
+  which previously skipped synthetic tests while gateways serving the v1
+  synthetic-test API were still rolling out.
+
 Removed:
 * Remove the `chronosphere_logscale_alert` and `chronosphere_logscale_action`
   resources. The endpoints backing them no longer exist in the public API.

--- a/chronosphere/pagination/pagination.gen.go
+++ b/chronosphere/pagination/pagination.gen.go
@@ -1728,7 +1728,40 @@ func ListSyntheticTestsByFilter(
 	f Filter,
 	opts ...func(*synthetic_test.ListSyntheticTestsParams),
 ) ([]*configv1models.Configv1SyntheticTest, error) {
-	return nil, nil
+	var (
+		nextToken string
+		result    []*configv1models.Configv1SyntheticTest
+	)
+	for {
+		p := &synthetic_test.ListSyntheticTestsParams{
+			Context:   ctx,
+			PageToken: &nextToken,
+			Slugs:     f.Slugs,
+			Names:     f.Names,
+		}
+		for _, opt := range opts {
+			opt(p)
+		}
+		resp, err := client.SyntheticTest.ListSyntheticTests(p)
+		if err != nil {
+			return nil, err
+		}
+
+		// If payload or page token aren't set, no next page.
+		nextToken = ""
+		if resp.Payload != nil {
+			for _, v := range resp.Payload.SyntheticTests {
+				result = append(result, v)
+			}
+			if resp.Payload.Page != nil {
+				nextToken = resp.Payload.Page.NextToken
+			}
+		}
+		if nextToken == "" {
+			break
+		}
+	}
+	return result, nil
 }
 
 func ListTeams(

--- a/chronosphere/registry/registry.go
+++ b/chronosphere/registry/registry.go
@@ -431,8 +431,5 @@ var Resources = mustValidate([]Resource{
 		Entity: "SyntheticTest",
 		API:    V1,
 		Schema: tfschema.SyntheticTest,
-		// Remove once gateways serving /v1/config/synthetic-tests are
-		// deployed to the environments the export/import tests run against.
-		DisableExportImport: true,
 	},
 })

--- a/chronosphere/resource_synthetics.go
+++ b/chronosphere/resource_synthetics.go
@@ -26,6 +26,11 @@ import (
 	"github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/tfschema"
 )
 
+// SyntheticTestFromModel maps an API model to an intschema model.
+func SyntheticTestFromModel(m *models.Configv1SyntheticTest) (*intschema.SyntheticTest, error) {
+	return syntheticTestConverter{}.fromModel(m)
+}
+
 func resourceSyntheticTest() *schema.Resource {
 	r := newGenericResource(
 		"synthetic_test",


### PR DESCRIPTION
Removes `DisableExportImport` from the `synthetic_test` registry entry and regenerates, so `ListSyntheticTestsByFilter` becomes a real paginated list call and export-config/import-state stop silently skipping synthetic tests. 