### PR TITLE
[terraform-provider] Add SLO type and latency threshold to chronosphere_slo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## UNRELEASED
 
 Added:
+* Add `slo_type` and `latency_threshold_nanos` to the `sli` block of
+  `chronosphere_slo`. Together they record whether an SLO measures endpoint
+  availability or latency, and for latency SLOs the threshold requests are
+  measured against. Both are optional and no query generation depends on
+  them, so leaving them unset keeps existing SLOs rendering as they do today.
 * Add the `chronosphere_synthetic_test` resource, which probes an endpoint over
   HTTP, DNS, TCP, or TLS from Chronosphere-operated locations and alerts on the
   result. Credentials are configured through write-only (`*_wo`) attributes and

--- a/chronosphere/enum/enum_test.go
+++ b/chronosphere/enum/enum_test.go
@@ -150,6 +150,10 @@ func TestAllEnumsValidate(t *testing.T) {
 			enum:          SLITimeSliceSize.ToStrings(),
 		},
 		{
+			v1SwaggerName: "SLISLOType",
+			enum:          SLISLOType.ToStrings(),
+		},
+		{
 			v1SwaggerName: "configv1LogRetentionConfigMode",
 			enum:          LogRetentionConfigMode.ToStrings(),
 		},

--- a/chronosphere/enum/sli_slo_type.go
+++ b/chronosphere/enum/sli_slo_type.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Chronosphere Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import (
+	configv1 "github.com/chronosphereio/terraform-provider-chronosphere/chronosphere/pkg/configv1/models"
+)
+
+// SLISLOType is an enum. It deliberately registers no default value: an unset
+// slo_type means the type was never declared, which reads differently from an
+// explicit ENDPOINT_AVAILABILITY.
+var SLISLOType = newEnum("SLISLOType", []value[configv1.SLISLOType]{
+	{
+		v1:    configv1.SLISLOTypeENDPOINTAVAILABILITY,
+		alias: "ENDPOINT_AVAILABILITY",
+	},
+	{
+		v1:    configv1.SLISLOTypeLATENCY,
+		alias: "LATENCY",
+	},
+})

--- a/chronosphere/intschema/slo.go
+++ b/chronosphere/intschema/slo.go
@@ -67,6 +67,8 @@ type SloSli struct {
 	CustomDimensionLabels    []string                        `intschema:"custom_dimension_labels,optional"`
 	CustomIndicator          *SloSliCustomIndicator          `intschema:"custom_indicator,optional,list_encoded_object"`
 	CustomTimesliceIndicator *SloSliCustomTimesliceIndicator `intschema:"custom_timeslice_indicator,optional,list_encoded_object"`
+	LatencyThresholdNanos    int64                           `intschema:"latency_threshold_nanos,optional"`
+	SloType                  string                          `intschema:"slo_type,optional"`
 }
 
 type SloSliCustomTimesliceIndicator struct {

--- a/chronosphere/resource_slo.go
+++ b/chronosphere/resource_slo.go
@@ -15,6 +15,8 @@
 package chronosphere
 
 import (
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"go.uber.org/atomic"
 
@@ -105,6 +107,8 @@ func (sloConverter) toModel(s *intschema.Slo) (*models.Configv1SLO, error) {
 			CustomTimesliceIndicator: customTimesliceIndicator,
 			CustomDimensionLabels:    s.Sli.CustomDimensionLabels,
 			AdditionalPromqlFilters:  promFiltersToModel(s.Sli.AdditionalPromqlFilters),
+			SLOType:                  enum.SLISLOType.V1(s.Sli.SloType),
+			LatencyThresholdNanos:    latencyThresholdNanosToModel(s.Sli.LatencyThresholdNanos),
 		},
 		SignalGrouping: monitorSignalGroupingToModel(s.SignalGrouping),
 		Annotations:    s.Annotations,
@@ -143,6 +147,11 @@ func (sloConverter) fromModel(
 		}
 	}
 
+	latencyThresholdNanos, err := parseStringToInt64(s.Sli.LatencyThresholdNanos, "latency_threshold_nanos")
+	if err != nil {
+		return nil, err
+	}
+
 	var collectionID tfid.ID
 	if s.CollectionRef.Type == models.Configv1CollectionReferenceTypeSIMPLE {
 		collectionID = tfid.Slug(s.CollectionRef.Slug)
@@ -167,11 +176,23 @@ func (sloConverter) fromModel(
 			CustomTimesliceIndicator: customTimesliceIndicator,
 			CustomDimensionLabels:    s.Sli.CustomDimensionLabels,
 			AdditionalPromqlFilters:  promFiltersFromModel(s.Sli.AdditionalPromqlFilters),
+			SloType:                  enum.SLISLOType.Alias(s.Sli.SLOType),
+			LatencyThresholdNanos:    latencyThresholdNanos,
 		},
 		SignalGrouping: monitorSignalGroupingFromModel(s.SignalGrouping),
 		Annotations:    s.Annotations,
 		Labels:         s.Labels,
 	}, nil
+}
+
+// latencyThresholdNanosToModel encodes the threshold as the string the API uses
+// for int64 fields. Zero is indistinguishable from unset in Terraform, and a
+// zero threshold is meaningless, so it serializes to the omitted empty string.
+func latencyThresholdNanosToModel(nanos int64) string {
+	if nanos == 0 {
+		return ""
+	}
+	return strconv.FormatInt(nanos, 10)
 }
 
 func unstableRefToV1(ref *models.Configv1CollectionReference) *models.Configv1CollectionReference {

--- a/chronosphere/slo_converter_test.go
+++ b/chronosphere/slo_converter_test.go
@@ -70,3 +70,78 @@ func TestSLOTimesliceIndicatorConversion(t *testing.T) {
 	assert.Equal(t, intSlo.Sli.CustomTimesliceIndicator.Condition.Op, intSloResult.Sli.CustomTimesliceIndicator.Condition.Op)
 	assert.Equal(t, intSlo.Sli.CustomTimesliceIndicator.Condition.Value, intSloResult.Sli.CustomTimesliceIndicator.Condition.Value)
 }
+
+func TestSLOTypeConversion(t *testing.T) {
+	newSLO := func(sloType string, nanos int64) *intschema.Slo {
+		return &intschema.Slo{
+			Name:         "test latency slo",
+			CollectionId: tfid.Slug("test-collection"),
+			Definition: intschema.SloDefinition{
+				Objective: 99.9,
+			},
+			Sli: intschema.SloSli{
+				CustomIndicator: &intschema.SloSliCustomIndicator{
+					GoodQueryTemplate:  `sum(rate(http_request_duration_seconds_bucket{le="0.05"}[{{.Window}}]))`,
+					TotalQueryTemplate: `sum(rate(http_request_duration_seconds_count[{{.Window}}]))`,
+				},
+				SloType:               sloType,
+				LatencyThresholdNanos: nanos,
+			},
+		}
+	}
+
+	converter := sloConverter{}
+
+	t.Run("latency", func(t *testing.T) {
+		intSlo := newSLO("LATENCY", 50000000)
+
+		model, err := converter.toModel(intSlo)
+		require.NoError(t, err)
+		assert.Equal(t, models.SLISLOTypeLATENCY, model.Sli.SLOType)
+		assert.Equal(t, "50000000", model.Sli.LatencyThresholdNanos)
+
+		result, err := converter.fromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "LATENCY", result.Sli.SloType)
+		assert.Equal(t, int64(50000000), result.Sli.LatencyThresholdNanos)
+	})
+
+	t.Run("availability", func(t *testing.T) {
+		intSlo := newSLO("ENDPOINT_AVAILABILITY", 0)
+
+		model, err := converter.toModel(intSlo)
+		require.NoError(t, err)
+		assert.Equal(t, models.SLISLOTypeENDPOINTAVAILABILITY, model.Sli.SLOType)
+		assert.Empty(t, model.Sli.LatencyThresholdNanos)
+
+		result, err := converter.fromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "ENDPOINT_AVAILABILITY", result.Sli.SloType)
+		assert.Zero(t, result.Sli.LatencyThresholdNanos)
+	})
+
+	// Configs written before the fields existed must round-trip untouched, so
+	// unset stays unset rather than defaulting to a declared type.
+	t.Run("unset", func(t *testing.T) {
+		intSlo := newSLO("", 0)
+
+		model, err := converter.toModel(intSlo)
+		require.NoError(t, err)
+		assert.Empty(t, model.Sli.SLOType)
+		assert.Empty(t, model.Sli.LatencyThresholdNanos)
+
+		result, err := converter.fromModel(model)
+		require.NoError(t, err)
+		assert.Empty(t, result.Sli.SloType)
+		assert.Zero(t, result.Sli.LatencyThresholdNanos)
+	})
+
+	t.Run("unparseable threshold", func(t *testing.T) {
+		model, err := converter.toModel(newSLO("LATENCY", 50000000))
+		require.NoError(t, err)
+		model.Sli.LatencyThresholdNanos = "not-a-number"
+
+		_, err = converter.fromModel(model)
+		require.ErrorContains(t, err, "latency_threshold_nanos")
+	})
+}

--- a/chronosphere/slo_timeslice_hcl_test.go
+++ b/chronosphere/slo_timeslice_hcl_test.go
@@ -116,6 +116,45 @@ resource "chronosphere_slo" "latency" {
 }
 `,
 		},
+		{
+			name: "latency type and threshold",
+			slo: &intschema.Slo{
+				HCLID:        "latency_type",
+				Name:         "latency slo",
+				CollectionId: tfid.Slug("test-collection"),
+				Definition: intschema.SloDefinition{
+					Objective: 99,
+				},
+				Sli: intschema.SloSli{
+					CustomIndicator: &intschema.SloSliCustomIndicator{
+						GoodQueryTemplate:  "sum(rate(http_request_duration_seconds_bucket{le=\"0.05\"}[{{.Window}}]))",
+						TotalQueryTemplate: "sum(rate(http_request_duration_seconds_count[{{.Window}}]))",
+					},
+					SloType:               "LATENCY",
+					LatencyThresholdNanos: 50000000,
+				},
+			},
+			want: `
+resource "chronosphere_slo" "latency_type" {
+  name          = "latency slo"
+  collection_id = "test-collection"
+
+  definition {
+    objective = 99
+  }
+
+  sli {
+    custom_indicator {
+      total_query_template = "sum(rate(http_request_duration_seconds_count[{{.Window}}]))"
+      good_query_template  = "sum(rate(http_request_duration_seconds_bucket{le=\"0.05\"}[{{.Window}}]))"
+    }
+
+    latency_threshold_nanos = 50000000
+    slo_type                = "LATENCY"
+  }
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/chronosphere/tfschema/slo.go
+++ b/chronosphere/tfschema/slo.go
@@ -159,6 +159,16 @@ var SLI = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 	},
 	"additional_promql_filters": SLOAdditionalPromQLFilters,
+	"slo_type": Enum{
+		Value:       enum.SLISLOType.ToStrings(),
+		Optional:    true,
+		Description: "What the SLO measures. No query generation depends on it: the queries are still authored through `custom_indicator` or `custom_timeslice_indicator`, and this only records the intent behind them. Leave unset to keep the pre-existing rendering.",
+	}.Schema(),
+	"latency_threshold_nanos": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "The latency that requests are measured against, in nanoseconds: `50000000` is the \"50ms\" in \"P99 < 50ms\". Required when `slo_type` is `LATENCY`, rejected otherwise.",
+	},
 }
 
 var SloCustomIndicator = map[string]*schema.Schema{

--- a/docs/resources/slo.md
+++ b/docs/resources/slo.md
@@ -54,6 +54,32 @@ resource "chronosphere_slo" "request_success" {
       bad_query_template   = "sum(rate(http_request_duration_seconds_count{error=\"true\"}[{{ .Window }}]))"
       total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
     }
+
+    slo_type = "ENDPOINT_AVAILABILITY"
+  }
+}
+
+resource "chronosphere_slo" "request_latency" {
+  name                   = "payments request latency"
+  collection_id          = chronosphere_collection.c.id
+  notification_policy_id = chronosphere_notification_policy.np.id
+
+  definition {
+    objective = 99
+    time_window {
+      duration = "28d"
+    }
+  }
+
+  sli {
+    custom_indicator {
+      good_query_template  = "sum(rate(http_request_duration_seconds_bucket{le=\"0.05\"}[{{ .Window }}]))"
+      total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
+    }
+
+    # 50ms, expressed in nanoseconds.
+    slo_type                = "LATENCY"
+    latency_threshold_nanos = 50000000
   }
 }
 ```
@@ -126,6 +152,8 @@ Optional:
 - `custom_dimension_labels` (List of String) Additional labels exported from the underlying queries to group the error budget by. Available in PromQL templates via `{{.GroupBy}}`.
 - `custom_indicator` (Block List, Max: 1) Error-ratio SLI defined by good/bad/total PromQL query templates. Mutually exclusive with `custom_timeslice_indicator`. (see [below for nested schema](#nestedblock--sli--custom_indicator))
 - `custom_timeslice_indicator` (Block List, Max: 1) Time-slice SLI that evaluates a PromQL query over fixed time slices against a threshold condition. Mutually exclusive with `custom_indicator`. (see [below for nested schema](#nestedblock--sli--custom_timeslice_indicator))
+- `latency_threshold_nanos` (Number) The latency that requests are measured against, in nanoseconds: `50000000` is the "50ms" in "P99 < 50ms". Required when `slo_type` is `LATENCY`, rejected otherwise.
+- `slo_type` (String) What the SLO measures. No query generation depends on it: the queries are still authored through `custom_indicator` or `custom_timeslice_indicator`, and this only records the intent behind them. Leave unset to keep the pre-existing rendering.
 
 <a id="nestedblock--sli--additional_promql_filters"></a>
 ### Nested Schema for `sli.additional_promql_filters`

--- a/examples/resources/chronosphere_slo/resource.tf
+++ b/examples/resources/chronosphere_slo/resource.tf
@@ -39,5 +39,31 @@ resource "chronosphere_slo" "request_success" {
       bad_query_template   = "sum(rate(http_request_duration_seconds_count{error=\"true\"}[{{ .Window }}]))"
       total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
     }
+
+    slo_type = "ENDPOINT_AVAILABILITY"
+  }
+}
+
+resource "chronosphere_slo" "request_latency" {
+  name                   = "payments request latency"
+  collection_id          = chronosphere_collection.c.id
+  notification_policy_id = chronosphere_notification_policy.np.id
+
+  definition {
+    objective = 99
+    time_window {
+      duration = "28d"
+    }
+  }
+
+  sli {
+    custom_indicator {
+      good_query_template  = "sum(rate(http_request_duration_seconds_bucket{le=\"0.05\"}[{{ .Window }}]))"
+      total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
+    }
+
+    # 50ms, expressed in nanoseconds.
+    slo_type                = "LATENCY"
+    latency_threshold_nanos = 50000000
   }
 }

--- a/examples/scenarios/slo/main.tf
+++ b/examples/scenarios/slo/main.tf
@@ -42,6 +42,7 @@ resource "chronosphere_slo" "slo" {
       total_query_template = "sum(rate(http_request_duration_seconds_count[{{ .Window }}]))"
     }
     custom_dimension_labels = ["label1", "label2"]
+    slo_type                = "ENDPOINT_AVAILABILITY"
   }
 }
 
@@ -246,5 +247,9 @@ resource "chronosphere_slo" "slo_with_timeslice_latency" {
       }
     }
     custom_dimension_labels = ["service"]
+
+    # 500ms, matching the 0.5 the timeslice condition compares against.
+    slo_type                = "LATENCY"
+    latency_threshold_nanos = 500000000
   }
 }


### PR DESCRIPTION
Adds `slo_type` and `latency_threshold_nanos` to the `sli` block of `chronosphere_slo`, matching the `SLI.slo_type` / `SLI.latency_threshold_nanos` fields already present in the v1 config API and in the checked-in swagger.

Together the two fields record what an SLO measures: endpoint availability, or latency against a threshold. Today a latency SLO is indistinguishable from an availability one once it reaches the API, so no surface can label it correctly. No query generation depends on either field; the queries are still authored through `custom_indicator` or `custom_timeslice_indicator`.

Both fields are optional and the new `SLISLOType` enum deliberately registers no default, so an unset `slo_type` round-trips as unset and existing configs plan clean. `latency_threshold_nanos` is a `TypeInt` in HCL and is encoded to the string form the API uses for int64 fields at the model boundary.

Tests cover converter round-trips (latency, availability, unset, unparseable threshold), HCL marshalling for the export path, and the swagger enum cross-check. Docs and the SLO examples are regenerated.

claude: pr-lifecycle